### PR TITLE
Two minor bugs when use model with DST sensitive data

### DIFF
--- a/rdtools/degradation.py
+++ b/rdtools/degradation.py
@@ -199,7 +199,7 @@ def degradation_year_on_year(normalized_energy, recenter=True):
     normalized_energy.index.name = 'dt'
 
     # Detect sub-daily data:
-    if min(np.diff(normalized_energy.index.values, n=1)) < np.timedelta64(24, 'h'):
+    if min(np.diff(normalized_energy.index.values, n=1)) < np.timedelta64(23, 'h'):
         raise ValueError('normalized_energy must not be more frequent than daily')
 
     # Detect less than 2 years of data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 nose==1.3.7
 numpy==1.11.2
-pandas==0.19.1
+pandas==0.19.2
 patsy==0.4.1
 pvlib==0.4.1
 python-dateutil==2.6.0


### PR DESCRIPTION
First error message
~~~
Traceback (most recent call last):
  File "rdtools_clearsky.py", line 218, in <module>
    yoy_rd, yoy_ci, yoy_info = rdtools.degradation_year_on_year(daily)
  File "/usr/local/lib/python2.7/site-packages/rdtools/degradation.py", line 203, in degradation_year_on_year
    raise ValueError('normalized_energy must not be more frequent than daily')
ValueError: normalized_energy must not be more frequent than daily
~~~

This is due to `'degradation_year_on_year'` checking `'normalized_energy'` to detect sub-daily data
~~~
    if min(np.diff(normalized_energy.index.values, n=1)) < np.timedelta64(24, 'h'):
        raise ValueError('normalized_energy must not be more frequent than daily')
~~~
now we have DST which `'min(np.diff(normalized_energy.index.values, n=1))'` give us 23 instead 24 hours therefore error raise.

Second error message
~~~
Traceback (most recent call last):
  File "original_clearsky.py", line 215, in <module>
    yoy_rd, yoy_ci, yoy_info = rdtools.degradation_year_on_year(daily)
  File "/usr/local/lib/python2.7/site-packages/rdtools/degradation.py", line 229, in degradation_year_on_year
    tolerance=pd.Timedelta('8D')
  File "/usr/local/lib/python2.7/site-packages/pandas/tools/merge.py", line 423, in merge_asof
    allow_exact_matches=allow_exact_matches)
  File "/usr/local/lib/python2.7/site-packages/pandas/tools/merge.py", line 975, in __init__
    fill_method=fill_method)
  File "/usr/local/lib/python2.7/site-packages/pandas/tools/merge.py", line 891, in __init__
    sort=True  # factorize sorts
  File "/usr/local/lib/python2.7/site-packages/pandas/tools/merge.py", line 496, in __init__
    self.join_names) = self._get_merge_keys()
  File "/usr/local/lib/python2.7/site-packages/pandas/tools/merge.py", line 1037, in _get_merge_keys
    raise MergeError(msg)
pandas.tools.merge.MergeError: incompatible tolerance, must be compat with type <class 'pandas.tseries.index.DatetimeIndex'>
~~~

This issue is due to Pandas version 0.19.1 merge_asof not supporting DatetimeIndex with timezone info, updating Pandas to 0.19.2 will solve this issue. **Don't update Pandas to most rencent 0.20. version, it will cause other issues.**

Please help review this minor changes and pull this branch.
