### PR TITLE
Fix erroneous check for two years of data

### DIFF
--- a/rdtools/degradation.py
+++ b/rdtools/degradation.py
@@ -206,7 +206,7 @@ def degradation_year_on_year(normalized_energy, recenter=True, exceedance_prob=9
         raise ValueError('normalized_energy must not be more frequent than daily')
 
     # Detect less than 2 years of data
-    if normalized_energy.index[-1] - normalized_energy.index[1] < pd.Timedelta('730h'):
+    if normalized_energy.index[-1] - normalized_energy.index[0] < pd.Timedelta('730d'):
         raise ValueError('must provide at least two years of normalized energy')
 
     # Auto center


### PR DESCRIPTION
Previous version was checking for data shorter than 730 **hours** rather than **days**. This is a minor change, @cdeline , can you please provide a quick review?