### PR TITLE
Update notebook_requirements for dependency security

### DIFF
--- a/docs/notebook_requirements.txt
+++ b/docs/notebook_requirements.txt
@@ -22,7 +22,7 @@ matplotlib==2.2.2
 mistune==0.8.3
 nbconvert==5.3.1
 nbformat==4.4.0
-notebook==5.6.0
+notebook==5.7.5
 numpy==1.15.2
 pandas==0.23.4
 pandocfilters==1.4.2


### PR DESCRIPTION
Minor change in `notebook_requirements.txt` to address github security alert for `notebook< 5.7.1`

Example notebook still runs fine after change. Since it doesn't touch the RdTools functions, I'll go ahead and merge.