### PR TITLE
Feat/performance ratio

### DIFF
--- a/rdtools/__init__.py
+++ b/rdtools/__init__.py
@@ -13,6 +13,8 @@ from rdtools.filtering import poa_filter
 from rdtools.filtering import tcell_filter
 from rdtools.filtering import clip_filter
 from rdtools.soiling import soiling_srr
+from rdtools.losses import performance_ratio
+from rdtools.losses import calculate_pr
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/rdtools/losses.py
+++ b/rdtools/losses.py
@@ -1,0 +1,136 @@
+"""
+The `losses` module contains functions for quantifying PV system performance.
+"""
+
+import pandas as pd
+import numpy as np
+import rdtools.normalization as normalization
+import pvlib
+
+
+def calculate_pr(power, expected_power, freq=None, filt=None, filter_na=True):
+    """
+    Calculate a system Performance Ratio (PR) using measured and expected
+    system power measurements.
+
+    Parameters
+    ----------
+    power : pd.Series
+        Measured system power.
+    expected_power : pd.Series
+        Modeled system power, coicident with `power`.  To follow the NREL
+        Weather-Corrected PR methodology, this should be calculated using the
+        PVWatts-style model P = kWdc * POA/1000 * (1 - gamma_pmpp * [T*-Tcell])
+    freq : pandas offset string, default None
+        Optionally, calculate PR on a rolled-up basis.  For example, pass
+        `freq='m'` to return a monthly PR series.  If omitted, a single value
+        is returned that represents the PR for the entire dataset.
+    filt : pd.Series, default None
+        Optionally, a boolean Series to filter the timeseries data before
+        calculating PR.  `True` values indicate measurements to keep.  This is
+        useful for filtering out things like clipping or low-light conditions.
+    filter_na : bool, default True
+        If `True`, remove timestamps where either `power` or `expected_power`
+        is missing.  Otherwise, treat null values like zero.
+
+    Returns
+    -------
+    PR : float or pd.Series
+        The calculated performance ratio as a single float (`freq is None`) or
+        a pd.Series (otherwise).
+    """
+
+    df = pd.DataFrame({'observed': power, 'expected': expected_power})
+
+    if filter_na:
+        # if either column is null, null out the entire timestamp
+        df.loc[df.isnull().any(axis=1), :] = np.nan
+    else:
+        df = df.fillna(0)
+
+    if filt is not None:
+        df.loc[filt, :] = np.nan
+
+    if freq is not None:
+        df = df.resample(freq)
+
+    rollup = df.sum()
+    PR = rollup['observed'] / rollup['expected']
+    return PR
+
+
+def performance_ratio(system_size, gamma_pdc, power, poa, tamb=None,
+                      tcell=None, wind=0.0, freq=None, clip_limit=None,
+                      low_light_limit=0.0, tcell_ref=25,
+                      temperature_model=None):
+    """
+    Calculate performance using the NREL Weather-Corrected Performance Ratio.
+
+    Parameters
+    ----------
+    system_size : float
+        System DC nameplate capacity.
+    gamma_pdc : float
+        Linear array efficiency temperature coefficient [1 / degree celsius].
+    power : pd.Series
+        Measured system power.  Units must match `system_size`.
+    poa : pd.Series
+        Plane-of-array irradiance measurements in W/m^2.
+    tamb : pd.Series, default None
+        Ambient temperature measurements in C.
+        Either `tamb` or `tmod` must be specified.
+    tcell : pd.Series, default None
+        Back-of-module temperature measurements in C.
+        Either `tamb` or `tcell` must be specified.
+    wind : pd.Series, default 0.0
+        Wind speed measurements in m/s.  If omitted, 0 m/s is used.
+    freq : pandas offset string, default None
+        Optionally, calculate PR on a rolled-up basis.  For example, pass
+        `freq='m'` to return a monthly PR series.  If omitted, a single value
+        is returned that represents the PR for the entire dataset.
+    clip_limit : float, default None
+        If specified, filter out times when expected power is above the
+        system's clipping limit.  Note that this filter is not included in [1].
+    low_light_limit : float, default 0.0
+        If specified, filter out times when POA irradiance is below the
+        low-light limit.  Note that this filter is not included in [1].
+    tcell_ref : float, default 25
+        The reference cell temperature in C.  In [1], the POA-weighted average
+        Tcell is used so that annual temperature-adjusted PR equals the
+        standard PR.  The default value of 25 C will yield PRs closer to 100%.
+    temperature_model : str, default None
+        An optional cell temperature model to use when calculating cell
+        temperature with `pvlib.pvsystem.sapm_celltemp`.  Only used if `tcell`
+        is not specified.
+
+    Returns
+    -------
+    PR : float or pd.Series
+        The calculated performance ratio as a single float (`freq is None`) or
+        a pd.Series (otherwise).
+
+    Reference
+    ---------
+    [1] T. Dierauf et. al. "Weather-Corrected Performance Ratio" 2013 NREL
+    Technical Report.  https://www.nrel.gov/docs/fy13osti/57991.pdf
+    """
+
+    if tcell is None:
+        if temperature_model is None:
+            tcell = pvlib.pvsystem.sapm_celltemp(poa, wind, tamb)
+        else:
+            tcell = pvlib.pvsystem.sapm_celltemp(poa, wind, tamb,
+                                                 model=temperature_model)
+
+    expected_power = normalization.pvwatts_dc_power(
+            poa, system_size, tcell, T_ref=tcell_ref, gamma_pdc=gamma_pdc
+    )
+
+    filt = pd.Series(index=power.index, data=True)
+    if clip_limit is not None:
+        filt = filt & (expected_power < clip_limit)
+    if low_light_limit is not None:
+        filt = filt & (poa > low_light_limit)
+
+    PR = calculate_pr(power, expected_power, freq=freq, filt=filt)
+    return PR

--- a/rdtools/losses.py
+++ b/rdtools/losses.py
@@ -49,7 +49,7 @@ def calculate_pr(power, expected_power, freq=None, filt=None, filter_na=True):
         df = df.fillna(0)
 
     if filt is not None:
-        df.loc[filt, :] = np.nan
+        df.loc[~filt, :] = np.nan
 
     if freq is not None:
         df = df.resample(freq)
@@ -89,8 +89,9 @@ def performance_ratio(system_size, gamma_pdc, power, poa, tamb=None,
         `freq='m'` to return a monthly PR series.  If omitted, a single value
         is returned that represents the PR for the entire dataset.
     clip_limit : float, default None
-        If specified, filter out times when expected power is above the
-        system's clipping limit.  Note that this filter is not included in [1].
+        If specified, filter out times when *expected* power (not actual power)
+        is above the system's clipping limit.  Note that this filter is not
+        included in [1].
     low_light_limit : float, default 0.0
         If specified, filter out times when POA irradiance is below the
         low-light limit.  Note that this filter is not included in [1].
@@ -107,7 +108,7 @@ def performance_ratio(system_size, gamma_pdc, power, poa, tamb=None,
     -------
     PR : float or pd.Series
         The calculated performance ratio as a single float (`freq is None`) or
-        a pd.Series (otherwise).
+        a pd.Series (otherwise).  Values are a ratio [0-1], not a percentage.
 
     Reference
     ---------

--- a/rdtools/test/losses_test.py
+++ b/rdtools/test/losses_test.py
@@ -1,0 +1,142 @@
+"""losses module tests"""
+
+import unittest
+import pandas as pd
+import numpy as np
+
+from rdtools.losses import calculate_pr, performance_ratio
+
+
+class PRTestCase(unittest.TestCase):
+    """
+    Unit tests for performance ratio functions
+    """
+
+    def setUp(self):
+        st = '2019-01-01 10:00'
+        ed = '2019-01-01 15:00'
+        kWdc = 100.0
+        gamma = -0.004
+
+        idx = pd.date_range(st, ed, freq='15min')
+        poa = pd.Series(index=idx, data=500)
+        tcell = pd.Series(index=idx, data=30)
+        power = kWdc * poa/1000 * (1 + gamma*(tcell - 25))
+
+        self.kWdc = kWdc
+        self.gamma = gamma
+        self.poa = poa
+        self.tcell = tcell
+        self.power = power
+        self.args = {
+            'system_size': kWdc,
+            'gamma_pdc': gamma,
+            'power': power,
+            'poa': poa,
+            'tcell': tcell
+        }
+
+    def test_calculate_pr_simple(self):
+        """test base case"""
+        pr = calculate_pr(self.power, self.power)
+        self.assertAlmostEqual(pr, 1.0)
+        pr = calculate_pr(0.5 * self.power, self.power)
+        self.assertAlmostEqual(pr, 0.5)
+
+    def test_calculate_pr_freq(self):
+        """test `freq` parameter to correctly roll-up results"""
+        power = self.power.copy()
+        power[:4] *= 0.25
+        pr = calculate_pr(power, self.power, freq='h')
+        self.assertTrue(hasattr(pr, 'index'))
+        self.assertEqual(pr.index.freqstr, 'H')
+        self.assertAlmostEqual(pr[0], 0.25)
+        self.assertAlmostEqual(pr[1:].mean(), 1.0)
+
+    def test_calculate_pr_filt(self):
+        """test `filt` parameter to correctly filter out data"""
+        # derate performance for some times, but filter them out so that
+        # returned PR is still 100%
+        power = self.power.copy()
+        power[:5] *= 0.5
+        filt = power == power.max()
+        pr = calculate_pr(power, self.power, filt=filt)
+        self.assertAlmostEqual(pr, 1.0)
+
+    def test_calculate_pr_filter_na(self):
+        """test `filter_na` to remove nan (True) or set to zero (False)"""
+        # null out first hour, plus first 15min of second hour
+        power = self.power.copy()
+        power[:5] = np.nan
+        pr = calculate_pr(power, self.power, freq='h', filter_na=True)
+        self.assertTrue(np.isnan(pr[0]))
+        self.assertAlmostEqual(pr[1], 1.0)
+
+        pr = calculate_pr(power, self.power, freq='h', filter_na=False)
+        self.assertTrue(pr[0] == 0)
+        self.assertAlmostEqual(pr[1], 0.75)
+
+    def test_performance_ratio_simple(self):
+        """test base case"""
+        pr = performance_ratio(**self.args)
+        self.assertEqual(pr, 1.0)
+
+        args = self.args.copy()
+        args['power'] *= 0.5
+        pr = performance_ratio(**args)
+        self.assertEqual(pr, 0.5)
+
+    def test_performance_ratio_gamma(self):
+        """test qualitative behavior of gamma"""
+        # make gamma more negative.  since Tcell = 30, this will bias P_exp low
+        args = self.args.copy()
+        args['gamma_pdc'] = -0.005
+        pr = performance_ratio(**args)
+        self.assertTrue(pr > 1.0)
+
+    def test_performance_ratio_freq(self):
+        """test `freq' parameter to correctly roll-up results"""
+        # derate first hour to have poor performance
+        args = self.args.copy()
+        args['power'][:4] *= 0.25
+        pr = performance_ratio(**args, freq='h')
+        self.assertTrue(hasattr(pr, 'index'))
+        self.assertEqual(pr.index.freqstr, 'H')
+        self.assertAlmostEqual(pr[0], 0.25)
+        self.assertAlmostEqual(pr[1:].mean(), 1.0)
+
+    def test_performance_ratio_clip_limit(self):
+        """test `clip_limit` to filter when system should be clipping"""
+        args = self.args.copy()
+        # set first timestamp to high-irradiance (should clip) and no power.
+        # if PR is still 100% then it filtered the point for clipping
+        args['poa'][0] = 1000
+        args['power'][0] = 0
+        pr = performance_ratio(**args, clip_limit=75)
+        self.assertAlmostEqual(pr, 1.0)
+        pr = performance_ratio(**args)
+        self.assertTrue(pr < 1.0)
+
+    def test_performance_ratio_low_light_limit(self):
+        """test `low_light_limit` parameter to remove"""
+        args = self.args.copy()
+        # set first timestamp to low-irradiance (should filter) and no power.
+        # if PR is still 100% then it filtered the point for low-light
+        args['poa'][0] = 50
+        args['power'][0] = 0
+        pr = performance_ratio(**args, low_light_limit=100)
+        self.assertAlmostEqual(pr, 1.0)
+        pr = performance_ratio(**args)
+        self.assertTrue(pr < 1.0)
+
+    def test_performance_ratio_tcell_ref(self):
+        """test `tcell_ref` parameter"""
+        # make tcell_ref = 0 to bias P_exp low
+        pr = performance_ratio(**self.args, tcell_ref=0)
+        self.assertTrue(pr > 1.0)
+        pr = performance_ratio(**self.args, tcell_ref=50)
+        self.assertTrue(pr < 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
References #127.  Step one of the bigger loss categorization project is to add the ability to calculate performance ratio.  The method chosen for now is the temperature-adjusted metric defined in [1].  I've put the code in a new file called `losses.py` in anticipation of future loss-quantification functions going there as well.  

The main user-facing function `performance_ratio` differs from the spec in two ways:
- optionally allowing the user to filter out times where the expected power would be above the system's clipping limit
- defaulting to 25 C as the reference cell temperature instead of the POA-weighted Tcell value calculated from a system's 8760.  The POA-weighted Tcell version is intended to give the same annual value as the standard (non-temp-adjusted) PR, which results in the values being centered around 0.8 or so depending on the system.  Using 25 as the reference shifts the values to centered around 1.0.  

The other function `calculate_pr` is more generic and allows a user to calculate a PR using a generic expected energy signal and filtering mask.  

[1] "Weather-Corrected Performance Ratio" - https://www.nrel.gov/docs/fy13osti/57991.pdf