### PR TITLE
Add developer notes section to sphinx docs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit = 
+    # _version.py doesn't count
+    rdtools/_version.py
+    # omit the test files themselves
+    rdtools/test/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # ignore coveralls yaml, coverge dir
 .coveralls.yml
 .coverage
+htmlcov/
 
 # ignore test cache
 .pytest_cache

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 python:
     version: 3.6
-    install:
-      - requirements: docs/sphinx/sphinx_requirements.txt
     use_system_site_packages: true
     pip_install: true
+    extra_requirements:
+        - doc

--- a/docs/sphinx/source/changelog/v2.0.0.rst
+++ b/docs/sphinx/source/changelog/v2.0.0.rst
@@ -23,6 +23,7 @@ Testing
 Documentation
 -------------
 * Create sphinx documentation and set up ReadTheDocs (:pull:`125`).
+* Add guides on running tests and building sphinx docs (:pull:`136`).
 
 Requirements
 ------------

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -100,6 +100,21 @@ And even a single test function:
 
     python -m pytest rdtools/test/soiling_test.py::test_soiling_srr
 
+You can also evaluate code coverage when running the test suite using the 
+`coverage <https://coverage.readthedocs.io>_` package:
+
+::
+
+    coverage run -m pytest
+    coverage report
+
+The first line runs the test suite and keeps track of exactly what lines of
+code were run during test execution.  The second line then prints out a
+summary report showing how much much of each source file was
+executed in the test suite.  If a percentage is below 100, that means a
+function isn't tested or a branch inside a function isn't tested.  To get
+specific details, you can run ``coverage html`` to generate a detailed HTML
+report at ``htmlcov/index.html`` to view in a browser.  
 
 Building documentation locally
 ------------------------------

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -12,6 +12,8 @@ Installing RdTools using pip will install a condensed version that
 doesn't include the full source code.  If you want to make changes to RdTools,
 you'll need to clone the RdTools source repository from Github with e.g.
 
+::
+
     git clone https://github.com/NREL/rdtools.git
 
 from the command line, or using a GUI git client like Github Desktop.  This
@@ -20,7 +22,7 @@ will clone the entire git repository onto your computer.
 Running the test suite
 ----------------------
 
-RdTools uses `PyTest<https://docs.pytest.org/en/latest/>`_ to run its test
+RdTools uses `PyTest <https://docs.pytest.org/en/latest/>`_ to run its test
 suite.  If you don't already have it installed:
 
 ::

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -40,13 +40,13 @@ want to wait around for the entire suite to finish:
 
 ::
 
-    python -m pytest rdtools\test\soiling_test.py
+    python -m pytest rdtools/test/soiling_test.py
 
 And even a single test function:
 
 ::
 
-    python -m pytest rdtools\test\soiling_test.py::test_soiling_srr
+    python -m pytest rdtools/test/soiling_test.py::test_soiling_srr
 
 
 Building Documentation
@@ -117,13 +117,6 @@ If you get an error like ``Pandoc wasn't found``, you can install it with conda:
 ::
 
     conda install -c conda-forge pandoc
-
-If you get a warning like ``Pygments lexer name 'ipython3' is not known``, your
-environment doesn't have ``ipython``.  You can install it from conda or pypi:
-
-::
-
-    pip install ipython
 
 The built documentation should be in ``rdtools/docs/sphinx/build`` and opening
 ``index.html`` with a web browser will display it.

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -35,14 +35,29 @@ You can install the dependencies along with RdTools itself from
 This will install the latest official release of RdTools.  If you want to work
 with a development version and you have cloned the Github repository to your
 computer, you can also install RdTools and dependencies by navigating to the
-repository root and running:
+repository root, switching to the branch you're interested in, for instance:
+
+::
+
+    git checkout development
+
+and running:
 
 ::
 
     pip install .
 
-This will install the development version of RdTools along with the current
-set of requirements. 
+This will install based on whatever RdTools branch you have checked out.  You
+can check what version is currently installed by inspecting
+``rdtools.__version__``:
+
+::
+
+    >>> rdtools.__version__
+    '1.2.0+188.g5a96bb2'
+
+The hex string at the end represents the hash of the git commit for your
+installed version.
 
 .. _installing-optional-dependencies:
 

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -101,7 +101,7 @@ And even a single test function:
     python -m pytest rdtools/test/soiling_test.py::test_soiling_srr
 
 You can also evaluate code coverage when running the test suite using the 
-`coverage <https://coverage.readthedocs.io>_` package:
+`coverage <https://coverage.readthedocs.io>`_ package:
 
 ::
 

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -21,15 +21,65 @@ you'll need to clone the RdTools source repository from Github with e.g.
 from the command line, or using a GUI git client like Github Desktop.  This
 will clone the entire git repository onto your computer.  
 
+Installing RdTools dependencies
+-------------------------------
+
+The packages necessary to run RdTools itself can be installed with ``pip``.
+You can install the dependencies along with RdTools itself from 
+`PyPI <https://pypi.org/project/rdtools/>`_:
+
+::
+
+    pip install rdtools
+
+This will install the latest official release of RdTools.  If you want to work
+with a development version and you have cloned the Github repository to your
+computer, you can also install RdTools and dependencies by navigating to the
+repository root and running:
+
+::
+
+    pip install .
+
+This will install the development version of RdTools along with the current
+set of requirements. 
+
+.. _installing-optional-dependencies:
+
+Installing optional dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RdTools has extra dependencies for running its test suite and building its
+documentation.  These packages aren't necessary for running RdTools itself and
+are only needed if you want to contribute source code to RdTools.  
+
+.. note::
+    These will install RdTools along with other packages necessary to build its
+    documentation and run its test suite.  We recommend doing this in a virtual
+    environment to keep package installations between projects separate!
+
+Optional dependencies can be installed with the special 
+`syntax <https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies>`_:
+
+::
+
+    pip install rdtools[test]  # test suite dependencies
+    pip install rdtools[doc]   # documentation dependecies
+
+Or, if your local repository has an updated dependencies list:
+
+::
+
+    pip install .[test]  # test suite dependencies
+    pip install .[doc]   # documentation dependecies
+
+
 Running the test suite
 ----------------------
 
 RdTools uses `pytest <https://docs.pytest.org/en/latest/>`_ to run its test
-suite.  If you don't already have it installed:
-
-::
-
-    pip install pytest
+suite.  If you haven't already, install the testing depencencies
+(:ref:`installing-optional-dependencies`).
 
 To run the entire test suite, navigate to the git repo folder and run
 
@@ -55,24 +105,8 @@ Building documentation locally
 ------------------------------
 
 RdTools uses `Sphinx <https://www.sphinx-doc.org/>`_ to build its documentation.
-
-Sphinx and the other required libraries can be installed with pip by
-installing the ``doc`` extras (see the `setuptools docs <https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies>`_
-for more info): 
-
-::
-
-    pip install rdtools[doc]
-
-or you can install from your own local git repo (run from the repo folder):
-
-::
-
-    pip install .[doc]
-
-This will install rdtools along with all the packages necessary to build its
-documentation.  We recommend doing this in a virtual environment to keep
-package installations between projects separate!
+If you haven't already, install the documentation depencencies
+(:ref:`installing-optional-dependencies`).
 
 Once the required packages are installed, change your console's working
 directory to ``rdtools/docs/sphinx`` and run

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -1,0 +1,107 @@
+.. _developer_notes:
+
+Developer Notes
+===============
+
+This page documents some of the workflows specific to RdTools development.
+
+Installing RdTools source code
+------------------------------
+
+Installing RdTools using pip will install a condensed version of RdTools that
+doesn't include the full source code.  If you want to make changes to RdTools,
+you'll need to clone the RdTools source repository from Github with e.g.
+
+    git clone https://github.com/NREL/rdtools.git
+
+from the command line, or using a GUI git client like Github Desktop.  This
+will clone the entire git repository onto your computer.  
+
+Running the test suite
+----------------------
+
+RdTools uses `PyTest<https://docs.pytest.org/en/latest/>`_ to run its test
+suite.  If you don't already have it installed:
+
+    pip install pytest
+
+To run the entire test suite, navigate to the git repo folder and run
+
+    python -m pytest rdtools
+
+For convenience, pytest lets you run tests for a single module if you don't
+want to wait around for the entire suite to finish:
+
+    python -m pytest rdtools\test\soiling_test.py
+
+And even a single test function:
+
+    python -m pytest rdtools\test\soiling_test.py::test_soiling_srr
+
+
+Building Documentation
+----------------------
+
+RdTools uses `Sphinx<https://www.sphinx-doc.org/>`_ to build its documentation.
+To build the documentation locally, you'll need to have a local copy of the git
+repository.  
+
+Sphinx and the other required libraries can be installed with pip by
+installing the `doc` extras (see `here<https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies>`_
+for more info): 
+
+    pip install rdtools[doc]
+
+or you can install from your own local git repo (run from the repo folder):
+
+    pip install .[doc]
+
+This will install rdtools along with all the packages necessary to build its
+documentation.  We recommend doing this in a virtual environment to keep
+package installations between projects separate!
+
+Once the required packages are installed, change your console's working
+directory to `rdtools/docs/sphinx` and run
+
+    make html
+
+Note that on Windows, you don't actually need the `make` utility installed for
+this to work because there is a `make.bat` in this directory.  Building the
+docs should result in output like this:
+
+    (venv)$ make html
+    Running Sphinx v1.8.5
+    making output directory...
+    [autosummary] generating autosummary for: api.rst, example.nblink, index.rst, readme_link.rst
+    [autosummary] generating autosummary for: C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.aggregation.aggregation_insol.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.aggregation.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.clearsky_temperature.get_clearsky_tamb.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.clearsky_temperature.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.degradation.degradation_classical_decomposition.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.degradation.degradation_ols.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.degradation.degradation_year_on_year.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.degradation.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.filtering.clip_filter.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.filtering.csi_filter.rst, ..., C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.normalization.normalize_with_pvwatts.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.normalization.normalize_with_sapm.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.normalization.pvwatts_dc_power.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.normalization.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.normalization.sapm_dc_power.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.normalization.t_step_nanoseconds.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.normalization.trapz_aggregate.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.soiling.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.soiling.soiling_srr.rst, C:\Users\KANDERSO\projects\rdtools\docs\sphinx\source\generated\rdtools.soiling.srr_analysis.rst
+    building [mo]: targets for 0 po files that are out of date
+    building [html]: targets for 4 source files that are out of date
+    updating environment: 33 added, 0 changed, 0 removed
+    reading sources... [100%] readme_link
+    looking for now-outdated files... none found
+    pickling environment... done
+    checking consistency... done
+    preparing documents... done
+    writing output... [100%] readme_link
+    generating indices... genindex py-modindex
+    writing additional pages... search
+    copying images... [100%] ../build/doctrees/nbsphinx/example_33_2.png
+    copying static files... done
+    copying extra files... done
+    dumping search index in English (code: en) ... done
+    dumping object inventory... done
+    build succeeded.
+    
+    The HTML pages are in build\html.
+
+If you get an error like `Pandoc wasn't found`, you can install it with conda:
+
+    conda install -c conda-forge pandoc
+
+If you get a warning like `Pygments lexer name 'ipython3' is not known`, your
+environment doesn't have `ipython`.  You can install it from conda or pypi:
+
+    pip install ipython
+
+The built documentation should be in `rdtools/docs/sphinx/build` and opening
+`index.html` with a web browser will display it.

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -85,20 +85,20 @@ To run the entire test suite, navigate to the git repo folder and run
 
 ::
 
-    python -m pytest rdtools
+    pytest
 
 For convenience, pytest lets you run tests for a single module if you don't
 want to wait around for the entire suite to finish:
 
 ::
 
-    python -m pytest rdtools/test/soiling_test.py
+    pytest rdtools/test/soiling_test.py
 
 And even a single test function:
 
 ::
 
-    python -m pytest rdtools/test/soiling_test.py::test_soiling_srr
+    pytest rdtools/test/soiling_test.py::test_soiling_srr
 
 You can also evaluate code coverage when running the test suite using the 
 `coverage <https://coverage.readthedocs.io>`_ package:

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -8,7 +8,7 @@ This page documents some of the workflows specific to RdTools development.
 Installing RdTools source code
 ------------------------------
 
-Installing RdTools using pip will install a condensed version of RdTools that
+Installing RdTools using pip will install a condensed version that
 doesn't include the full source code.  If you want to make changes to RdTools,
 you'll need to clone the RdTools source repository from Github with e.g.
 
@@ -23,18 +23,26 @@ Running the test suite
 RdTools uses `PyTest<https://docs.pytest.org/en/latest/>`_ to run its test
 suite.  If you don't already have it installed:
 
+::
+
     pip install pytest
 
 To run the entire test suite, navigate to the git repo folder and run
+
+::
 
     python -m pytest rdtools
 
 For convenience, pytest lets you run tests for a single module if you don't
 want to wait around for the entire suite to finish:
 
+::
+
     python -m pytest rdtools\test\soiling_test.py
 
 And even a single test function:
+
+::
 
     python -m pytest rdtools\test\soiling_test.py::test_soiling_srr
 
@@ -42,17 +50,21 @@ And even a single test function:
 Building Documentation
 ----------------------
 
-RdTools uses `Sphinx<https://www.sphinx-doc.org/>`_ to build its documentation.
+RdTools uses `Sphinx <https://www.sphinx-doc.org/>`_ to build its documentation.
 To build the documentation locally, you'll need to have a local copy of the git
 repository.  
 
 Sphinx and the other required libraries can be installed with pip by
-installing the `doc` extras (see `here<https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies>`_
+installing the `doc` extras (see `here <https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies>`_
 for more info): 
+
+::
 
     pip install rdtools[doc]
 
 or you can install from your own local git repo (run from the repo folder):
+
+::
 
     pip install .[doc]
 
@@ -61,13 +73,17 @@ documentation.  We recommend doing this in a virtual environment to keep
 package installations between projects separate!
 
 Once the required packages are installed, change your console's working
-directory to `rdtools/docs/sphinx` and run
+directory to ``rdtools/docs/sphinx`` and run
+
+::
 
     make html
 
-Note that on Windows, you don't actually need the `make` utility installed for
-this to work because there is a `make.bat` in this directory.  Building the
+Note that on Windows, you don't actually need the ``make`` utility installed for
+this to work because there is a ``make.bat`` in this directory.  Building the
 docs should result in output like this:
+
+::
 
     (venv)$ make html
     Running Sphinx v1.8.5
@@ -94,14 +110,18 @@ docs should result in output like this:
     
     The HTML pages are in build\html.
 
-If you get an error like `Pandoc wasn't found`, you can install it with conda:
+If you get an error like ``Pandoc wasn't found``, you can install it with conda:
+
+::
 
     conda install -c conda-forge pandoc
 
-If you get a warning like `Pygments lexer name 'ipython3' is not known`, your
-environment doesn't have `ipython`.  You can install it from conda or pypi:
+If you get a warning like ``Pygments lexer name 'ipython3' is not known``, your
+environment doesn't have ``ipython``.  You can install it from conda or pypi:
+
+::
 
     pip install ipython
 
-The built documentation should be in `rdtools/docs/sphinx/build` and opening
-`index.html` with a web browser will display it.
+The built documentation should be in ``rdtools/docs/sphinx/build`` and opening
+``index.html`` with a web browser will display it.

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -154,3 +154,17 @@ If you get an error like ``Pandoc wasn't found``, you can install it with conda:
 
 The built documentation should be in ``rdtools/docs/sphinx/build`` and opening
 ``index.html`` with a web browser will display it.
+
+Code requirements
+-----------------
+
+RdTools follows the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guide.
+We recommend setting up your text editor to automatically highlight style
+violations because it's easy to miss some isses (trailing whitespace, etc) otherwise.
+
+Additionally, our documentation is built in part from docstrings in the source
+code.  These docstrings must be in `NumpyDoc format <https://numpydoc.readthedocs.io/en/latest/format.html>`_
+to be rendered correctly in the documentation.  
+
+Finally, all code should be tested.  Some older tests in RdTools use the unittest
+module, but new tests should all use pytest. 

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -8,8 +8,10 @@ This page documents some of the workflows specific to RdTools development.
 Installing RdTools source code
 ------------------------------
 
+To make changes to RdTools, run the test suite, or build the documentation
+locally, you'll need to have a local copy of the git repository.
 Installing RdTools using pip will install a condensed version that
-doesn't include the full source code.  If you want to make changes to RdTools,
+doesn't include the full source code.  To get the full source code,
 you'll need to clone the RdTools source repository from Github with e.g.
 
 ::
@@ -22,7 +24,7 @@ will clone the entire git repository onto your computer.
 Running the test suite
 ----------------------
 
-RdTools uses `PyTest <https://docs.pytest.org/en/latest/>`_ to run its test
+RdTools uses `pytest <https://docs.pytest.org/en/latest/>`_ to run its test
 suite.  If you don't already have it installed:
 
 ::
@@ -49,15 +51,13 @@ And even a single test function:
     python -m pytest rdtools/test/soiling_test.py::test_soiling_srr
 
 
-Building Documentation
-----------------------
+Building documentation locally
+------------------------------
 
 RdTools uses `Sphinx <https://www.sphinx-doc.org/>`_ to build its documentation.
-To build the documentation locally, you'll need to have a local copy of the git
-repository.  
 
 Sphinx and the other required libraries can be installed with pip by
-installing the `doc` extras (see `here <https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies>`_
+installing the ``doc`` extras (see the `setuptools docs <https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies>`_
 for more info): 
 
 ::

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -22,6 +22,7 @@ Documentation Contents
 
    In-Depth Examples <example>
    API Reference <api>
+   Developer Notes <developer_notes>
 
 Indices and tables
 ==================

--- a/docs/sphinx/sphinx_requirements.txt
+++ b/docs/sphinx/sphinx_requirements.txt
@@ -1,5 +1,0 @@
-m2r==0.2.1
-nbsphinx==0.4.3
-nbsphinx-link==1.3.0
-pandas==0.23.0
-pvlib==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ EXTRAS_REQUIRE = {
     ],
     'test': [
         'pytest',
+        'coverage',
     ]
 }
 EXTRAS_REQUIRE['all'] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,20 @@ INSTALL_REQUIRES = [
     'pvlib >= 0.6.0, <0.7.0',
 ]
 
+EXTRAS_REQUIRE = {
+    'doc': [
+        'sphinx==1.8.5',
+        'm2r==0.2.1',
+        'nbsphinx==0.4.3',
+        'nbsphinx-link==1.3.0',
+        'pandas==0.23.0',
+        'pvlib==0.6.1',
+        'sphinx_rtd_theme==0.4.3'
+    ]
+}
+EXTRAS_REQUIRE['all'] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))
+
+
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'License :: OSI Approved :: MIT License',
@@ -83,6 +97,7 @@ setup(name=DISTNAME,
       setup_requires=SETUP_REQUIRES,
       tests_require=TESTS_REQUIRE,
       install_requires=INSTALL_REQUIRES,
+      extras_require=EXTRAS_REQUIRE,
       description=DESCRIPTION,
       long_description=LONG_DESCRIPTION,
       author=AUTHOR,

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ EXTRAS_REQUIRE = {
         'pvlib==0.6.1',
         'sphinx_rtd_theme==0.4.3',
         'ipython',
+    ],
+    'test': [
+        'pytest',
     ]
 }
 EXTRAS_REQUIRE['all'] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ EXTRAS_REQUIRE = {
         'nbsphinx-link==1.3.0',
         'pandas==0.23.0',
         'pvlib==0.6.1',
-        'sphinx_rtd_theme==0.4.3'
+        'sphinx_rtd_theme==0.4.3',
+        'ipython',
     ]
 }
 EXTRAS_REQUIRE['all'] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))


### PR DESCRIPTION
This PR:
- Adds a sphinx page with instructions on running the test suite and building docs locally
- Deletes the sphinx_requirements.txt file and replaces it with an `extras_require` section called `doc` in setup.py.  This lets you do `pip install rdtools[doc]` to install both the normal rdtools requirements and the doc requirements in one go. 

Any objections to the second bullet?  I think specifying requirements in setup.py is generally preferred over requirements.txt files.  Suggestions for the "developer notes" page are welcome as well of course.

Built version here: https://rdtools.readthedocs.io/en/developer_notes/developer_notes.html