### PR TITLE
Improve module-level docstrings

### DIFF
--- a/docs/sphinx/source/changelog/v2.0.0.rst
+++ b/docs/sphinx/source/changelog/v2.0.0.rst
@@ -23,6 +23,7 @@ Testing
 Documentation
 -------------
 * Create sphinx documentation and set up ReadTheDocs (:pull:`125`).
+* Improve module-level docstrings (:pull:`137`).
 
 Requirements
 ------------

--- a/rdtools/aggregation.py
+++ b/rdtools/aggregation.py
@@ -1,6 +1,5 @@
-'''
-Aggregation Helper Functions
-'''
+'''Functions for calculating weighted aggregates of PV system data.'''
+
 
 def aggregation_insol(normalized_energy, insolation, frequency='D'):
     '''

--- a/rdtools/clearsky_temperature.py
+++ b/rdtools/clearsky_temperature.py
@@ -1,3 +1,5 @@
+'''Functions for estimating clear-sky ambient temperature.'''
+
 import h5py
 from numpy import arange
 from datetime import timedelta
@@ -5,6 +7,7 @@ import pandas as pd
 import pkg_resources
 import numpy as np
 import warnings
+
 
 def get_clearsky_tamb(times, latitude, longitude, window_size=40,
                       gauss_std=20):

--- a/rdtools/degradation.py
+++ b/rdtools/degradation.py
@@ -1,8 +1,4 @@
-''' Degradation Module
-
-This module contains functions to calculate the degradation rate of
-photovoltaic systems.
-'''
+'''Functions for calculating the degradation rate of photovoltaic systems.'''
 
 from __future__ import division
 import pandas as pd

--- a/rdtools/filtering.py
+++ b/rdtools/filtering.py
@@ -1,4 +1,4 @@
-import pandas as pd
+'''Functions for filtering and subsetting PV system data.'''
 
 
 def poa_filter(poa, low_irradiance_cutoff=200, high_irradiance_cutoff=1200):

--- a/rdtools/normalization.py
+++ b/rdtools/normalization.py
@@ -1,8 +1,4 @@
-''' Energy Normalization Module
-
-This module contains functions to help normalize AC energy output with measured
-poa_global in preparation for calculating PV system degradation.
-'''
+'''Functions for normalizing, rescaling, and regularizing PV system data.'''
 
 import pandas as pd
 import pvlib

--- a/rdtools/soiling.py
+++ b/rdtools/soiling.py
@@ -1,8 +1,4 @@
-''' Soiling Module
-
-This module contains functions to calculate soiling
-metrics from photovoltaic system data.
-'''
+'''Functions for calculating soiling metrics from photovoltaic system data.'''
 
 from __future__ import division
 import pandas as pd


### PR DESCRIPTION
Currently the module docstrings make for lackluster documentation because sphinx grabs the first line of the string: https://rdtools.readthedocs.io/en/latest/api.html#submodules

This PR moves information around so that the API reference is a little more useful:

![image](https://user-images.githubusercontent.com/57452607/73578358-b1352c80-443c-11ea-9bef-d70ca96530db.png)
