### PR TITLE
Workaround for reindexing bug in Pandas 1.0.0

### DIFF
--- a/rdtools/clearsky_temperature.py
+++ b/rdtools/clearsky_temperature.py
@@ -103,7 +103,13 @@ def get_clearsky_tamb(times, latitude, longitude, window_size=40,
     df = df.resample(freq_actual).interpolate(method='linear')
     df['month'] = df.index.month
 
+    # workaround for pandas #26683 reindexing bug in pandas 1.0.0
+    tz = times.tz
+    df.index = df.index.tz_convert('UTC').tz_localize(None)
+    times = times.tz_convert('UTC').tz_localize(None)
     df = df.reindex(times, method='nearest')
+    times = times.tz_localize('UTC').tz_convert(tz)
+    df.index = df.index.tz_localize('UTC').tz_convert(tz)
 
     utc_offsets = [y.utcoffset().total_seconds() / 3600.0 for y in df.index]
 

--- a/rdtools/clearsky_temperature.py
+++ b/rdtools/clearsky_temperature.py
@@ -103,13 +103,7 @@ def get_clearsky_tamb(times, latitude, longitude, window_size=40,
     df = df.resample(freq_actual).interpolate(method='linear')
     df['month'] = df.index.month
 
-    # workaround for pandas #26683 reindexing bug in pandas 1.0.0
-    tz = times.tz
-    df.index = df.index.tz_convert('UTC').tz_localize(None)
-    times = times.tz_convert('UTC').tz_localize(None)
     df = df.reindex(times, method='nearest')
-    times = times.tz_localize('UTC').tz_convert(tz)
-    df.index = df.index.tz_localize('UTC').tz_convert(tz)
 
     utc_offsets = [y.utcoffset().total_seconds() / 3600.0 for y in df.index]
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ TESTS_REQUIRE = [
 
 INSTALL_REQUIRES = [
     'numpy >= 1.12',
-    'pandas >= 0.23.0, <1.0.0, >=1.0.2',  # exclude 1.0.0 & 1.0.1 for GH142
+    'pandas >= 0.23.0,!=1.0.0,!=1.0.1',  # exclude 1.0.0 & 1.0.1 for GH142
     'statsmodels >= 0.8.0',
     'scipy >= 0.19.1',
     'h5py >= 2.7.1',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ TESTS_REQUIRE = [
 
 INSTALL_REQUIRES = [
     'numpy >= 1.12',
-    'pandas >= 0.23.0, <=1.0.0',
+    'pandas >= 0.23.0, <1.0.0, >=1.0.2',  # exclude 1.0.0 & 1.0.1 for GH142
     'statsmodels >= 0.8.0',
     'scipy >= 0.19.1',
     'h5py >= 2.7.1',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ TESTS_REQUIRE = [
 
 INSTALL_REQUIRES = [
     'numpy >= 1.12',
-    'pandas >= 0.23.0, <1.0.0',
+    'pandas >= 0.23.0, <=1.0.0',
     'statsmodels >= 0.8.0',
     'scipy >= 0.19.1',
     'h5py >= 2.7.1',


### PR DESCRIPTION
Calling `df.reindex(times, method='nearest')` with tz-aware indexes raises an error in `pandas 1.0.0` (see https://github.com/pandas-dev/pandas/issues/26683 and https://github.com/pandas-dev/pandas/pull/31511).  This works around it by dropping and restoring the timezones so that the reindex is performed on tz-naive indexes.  The intermediate UTC conversion is to avoid DST issues when relocalizing.

FYI after making this change, tests all pass for me with pandas 1.0.0 installed.  