### PR TITLE
Port data quality checks from solarforecastarbiter

### DIFF
--- a/rdtools/__init__.py
+++ b/rdtools/__init__.py
@@ -14,6 +14,7 @@ from rdtools.filtering import tcell_filter
 from rdtools.filtering import clip_filter
 from rdtools.filtering import stale_values_filter
 from rdtools.filtering import interpolation_filter
+from rdtools import qcrad
 from rdtools.soiling import soiling_srr
 
 from ._version import get_versions

--- a/rdtools/__init__.py
+++ b/rdtools/__init__.py
@@ -14,6 +14,7 @@ from rdtools.filtering import tcell_filter
 from rdtools.filtering import clip_filter
 from rdtools.filtering import stale_values_filter
 from rdtools.filtering import interpolation_filter
+from rdtools.filtering import irradiance_limits_filter
 from rdtools import qcrad
 from rdtools.soiling import soiling_srr
 

--- a/rdtools/__init__.py
+++ b/rdtools/__init__.py
@@ -13,6 +13,7 @@ from rdtools.filtering import poa_filter
 from rdtools.filtering import tcell_filter
 from rdtools.filtering import clip_filter
 from rdtools.filtering import stale_values_filter
+from rdtools.filtering import interpolation_filter
 from rdtools.soiling import soiling_srr
 
 from ._version import get_versions

--- a/rdtools/__init__.py
+++ b/rdtools/__init__.py
@@ -15,6 +15,7 @@ from rdtools.filtering import clip_filter
 from rdtools.filtering import stale_values_filter
 from rdtools.filtering import interpolation_filter
 from rdtools.filtering import irradiance_limits_filter
+from rdtools.filtering import irradiance_consistency_filter
 from rdtools import qcrad
 from rdtools.soiling import soiling_srr
 

--- a/rdtools/__init__.py
+++ b/rdtools/__init__.py
@@ -12,6 +12,7 @@ from rdtools.filtering import csi_filter
 from rdtools.filtering import poa_filter
 from rdtools.filtering import tcell_filter
 from rdtools.filtering import clip_filter
+from rdtools.filtering import stale_values_filter
 from rdtools.soiling import soiling_srr
 
 from ._version import get_versions

--- a/rdtools/filtering.py
+++ b/rdtools/filtering.py
@@ -151,3 +151,42 @@ def stale_values_filter(data, window=3, rtol=1e-5, atol=1e-8):
         _all_close_to_first, raw=True, kwargs={'rtol': rtol, 'atol': atol}
     ).fillna(False).astype(bool)
     return flags
+
+
+def interpolation_filter(data, window=3, rtol=1e-5, atol=1e-8):
+    '''
+    Detects sequences of data which appear linear.
+
+    Sequences are linear if the first difference appears to be constant.
+    For a window of length N, the last value (index N-1) is flagged
+    if all values in the window appear to be a line segment.
+
+    Parameters
+    ----------
+    data : pd.Series
+        data to be processed
+    window : int, default 3
+        number of sequential values that, if the first difference is constant,
+        are classified as a linear sequence
+    rtol : float, default 1e-5
+        tolerance relative to max(abs(x.diff()) for detecting a change
+    atol : float, default 1e-8
+        absolute tolerance for detecting a change in first difference
+
+    Returns
+    -------
+    pd.Series
+        True if the value is part of a linear sequence
+
+    Raises
+    ------
+        ValueError if window < 3
+    '''
+    if window < 3:
+        raise ValueError('window set to {}, must be at least 3'.format(window))
+
+    # reduce window by 1 because we're passing the first difference
+    flags = stale_values_filter(data.diff(periods=1), window=window-1, rtol=rtol,
+                                atol=atol)
+    return flags
+

--- a/rdtools/filtering.py
+++ b/rdtools/filtering.py
@@ -243,3 +243,43 @@ def irradiance_limits_filter(latitude, longitude, altitude,
 
     return qcrad.check_irradiance_limits(
         solar_position['zenith'], dni_extra, ghi=ghi, dhi=dhi, dni=dni)
+
+def irradiance_consistency_filter(latitude, longitude, altitude, ghi, dhi, dni):
+    '''Filter times when irradiance measurements are inconsistent.
+
+    Uses the QCRad algorithm to check for consistency. The results are
+    not valid for night time.
+
+    Parameters
+    ----------
+    latitude : float
+        Latitude of irradiance observations.
+    longitude : float
+        Longitude of irradiance observations.
+    altitude : float
+        Altitude of irradiance observations.
+    ghi : pd.Series
+        Obververd GHI in W/m^2
+    dhi : pd.Series
+        Observed DHI in W/m^2
+    dni : pd.Series
+        Observed DNI in W/m^2
+
+    Returns
+    -------
+    consistent_components : Series
+        True if ghi, dhi and dni components are consistent.
+    diffuse_ratio_limit : Series
+        True if diffuse to ghi ratio passes limit test.
+
+    '''
+    solar_position = solarposition.get_solarposition(
+        ghi.index,
+        latitude,
+        longitude,
+        altitude
+    )
+    dni_extra = get_extra_radiation(ghi.index)
+
+    return qcrad.check_irradiance_consistency(ghi, solar_position['zenith'],
+                                              dni_extra, dhi, dni)

--- a/rdtools/qcrad.py
+++ b/rdtools/qcrad.py
@@ -271,7 +271,7 @@ def check_irradiance_consistency(ghi, solar_zenith, dni_extra, dhi, dni,
         Diffuse horizontal irradiance in W/m^2
     dni : Series
         Direct normal irradiance in W/m^2
-    param : dict
+    param : dict, default None
         keys are 'ghi_ratio' and 'dhi_ratio'. For each key, value is a dict
         with keys 'high_zenith' and 'low_zenith'; for each of these keys,
         value is a dict with keys 'zenith_bounds', 'ghi_bounds', and

--- a/rdtools/qcrad.py
+++ b/rdtools/qcrad.py
@@ -1,5 +1,8 @@
 '''Implementation of the QCRad algorithm for validating irradiance
-obseervations.'''
+obseervations.
+
+@author: Cliff Hansen
+'''
 
 import pandas as pd
 import numpy as np

--- a/rdtools/qcrad.py
+++ b/rdtools/qcrad.py
@@ -1,0 +1,316 @@
+'''Implementation of the QCRad algorithm for validating irradiance
+obseervations.'''
+
+import pandas as pd
+import numpy as np
+from pvlib.tools import cosd
+
+QCRAD_LIMITS = {'ghi_ub': {'mult': 1.5, 'exp': 1.2, 'min': 100},
+                'dhi_ub': {'mult': 0.95, 'exp': 1.2, 'min': 50},
+                'dni_ub': {'mult': 1.0, 'exp': 0.0, 'min': 0},
+                'ghi_lb': -4, 'dhi_lb': -4, 'dni_lb': -4}
+
+QCRAD_CONSISTENCY = {
+    'ghi_ratio': {
+        'low_zenith': {
+            'zenith_bounds': [0.0, 75],
+            'ghi_bounds': [50, np.Inf],
+            'ratio_bounds': [0.92, 1.08]},
+        'high_zenith': {
+            'zenith_bounds': [75, 93],
+            'ghi_bounds': [50, np.Inf],
+            'ratio_bounds': [0.85, 1.15]}},
+    'dhi_ratio': {
+        'low_zenith': {
+            'zenith_bounds': [0.0, 75],
+            'ghi_bounds': [50, np.Inf],
+            'ratio_bounds': [0.0, 1.05]},
+        'high_zenith': {
+            'zenith_bounds': [75, 93],
+            'ghi_bounds': [50, np.Inf],
+            'ratio_bounds': [0.0, 1.10]}}}
+
+
+def _QCRad_ub(dni_extra, sza, lim):
+    cosd_sza = cosd(sza)
+    cosd_sza[cosd_sza < 0] = 0
+    return lim['mult'] * dni_extra * cosd_sza**lim['exp'] + lim['min']
+
+
+def _check_limits(val, lb=None, ub=None, lb_ge=False, ub_le=False):
+    """ Returns True where lb < (or <=) val < (or <=) ub
+    """
+    if lb_ge:
+        lb_op = np.greater_equal
+    else:
+        lb_op = np.greater
+    if ub_le:
+        ub_op = np.less_equal
+    else:
+        ub_op = np.less
+
+    if (lb is not None) & (ub is not None):
+        return lb_op(val, lb) & ub_op(val, ub)
+    elif lb is not None:
+        return lb_op(val, lb)
+    elif ub is not None:
+        return ub_op(val, ub)
+    else:
+        raise ValueError('must provide either upper or lower bound')
+
+
+def check_ghi_limits(ghi, solar_zenith, dni_extra, limits=None):
+    '''
+    Tests for physical limits on GHI using the QCRad criteria.
+
+    Test passes if a value > lower bound and value < upper bound. Lower bounds
+    are constant for all tests. Upper bounds are calculated as
+    .. math::
+        ub = min + mult * dni_extra * cos( solar_zenith)^exp
+
+    Parameters
+    ----------
+    ghi : Series
+        Global horizontal irradiance in W/m^2
+    solar_zenith : Series
+        Solar zenith angle in degrees
+    dni_extra : Series
+        Extraterrestrial normal irradiance in W/m^2
+    limits : dict, default QCRAD_LIMITS
+        for keys 'ghi_ub', 'dhi_ub', 'dni_ub', value is a dict with
+        keys {'mult', 'exp', 'min'}. For keys 'ghi_lb', 'dhi_lb', 'dni_lb',
+        value is a float.
+
+    Returns
+    -------
+    ghi_limit_flag : Series
+        True if value passes physically-possible test
+    '''
+    if not limits:
+        limits = QCRAD_LIMITS
+    ghi_ub = _QCRad_ub(dni_extra, solar_zenith, limits['ghi_ub'])
+
+    ghi_limit_flag = _check_limits(ghi, limits['ghi_lb'], ghi_ub)
+    ghi_limit_flag.name = 'ghi_limit_flag'
+
+    return ghi_limit_flag
+
+
+def check_dhi_limits(dhi, solar_zenith, dni_extra, limits=None):
+    '''
+    Tests for physical limits on DHI using the QCRad criteria.
+
+    Test passes if a value > lower bound and value < upper bound. Lower bounds
+    are constant for all tests. Upper bounds are calculated as
+    .. math::
+        ub = min + mult * dni_extra * cos( solar_zenith)^exp
+
+    Parameters
+    ----------
+    dhi : Series
+        Diffuse horizontal irradiance in W/m^2
+    solar_zenith : Series
+        Solar zenith angle in degrees
+    dni_extra : Series
+        Extraterrestrial normal irradiance in W/m^2
+    limits : dict, default QCRAD_LIMITS
+        for keys 'ghi_ub', 'dhi_ub', 'dni_ub', value is a dict with
+        keys {'mult', 'exp', 'min'}. For keys 'ghi_lb', 'dhi_lb', 'dni_lb',
+        value is a float.
+
+    Returns
+    -------
+    dhi_limit_flag : Series
+        True if value passes physically-possible test
+    '''
+    if not limits:
+        limits = QCRAD_LIMITS
+
+    dhi_ub = _QCRad_ub(dni_extra, solar_zenith, limits['dhi_ub'])
+
+    dhi_limit_flag = _check_limits(dhi, limits['dhi_lb'], dhi_ub)
+    dhi_limit_flag.name = 'dhi_limit_flag'
+
+    return dhi_limit_flag
+
+
+def check_dni_limits(dni, solar_zenith, dni_extra, limits=None):
+    '''
+    Tests for physical limits on DNI using the QCRad criteria.
+
+    Test passes if a value > lower bound and value < upper bound. Lower bounds
+    are constant for all tests. Upper bounds are calculated as
+    .. math::
+        ub = min + mult * dni_extra * cos( solar_zenith)^exp
+
+    Parameters
+    ----------
+    dni : Series
+        Direct normal irradiance in W/m^2
+    solar_zenith : Series
+        Solar zenith angle in degrees
+    dni_extra : Series
+        Extraterrestrial normal irradiance in W/m^2
+    limits : dict, default QCRAD_LIMITS
+        for keys 'ghi_ub', 'dhi_ub', 'dni_ub', value is a dict with
+        keys {'mult', 'exp', 'min'}. For keys 'ghi_lb', 'dhi_lb', 'dni_lb',
+        value is a float.
+
+    Returns
+    -------
+    dni_limit_flag : Series
+        True if value passes physically-possible test
+    '''
+    if not limits:
+        limits = QCRAD_LIMITS
+
+    dni_ub = _QCRad_ub(dni_extra, solar_zenith, limits['dni_ub'])
+
+    dni_limit_flag = _check_limits(dni, limits['dni_lb'], dni_ub)
+    dni_limit_flag.name = 'dni_limit_flag'
+
+    return dni_limit_flag
+
+
+def check_irradiance_limits(solar_zenith, dni_extra, ghi=None, dhi=None,
+                                  dni=None, limits=None):
+    '''
+    Tests for physical limits on GHI, DHI or DNI using the QCRad criteria.
+
+    Test passes if a value > lower bound and value < upper bound. Lower bounds
+    are constant for all tests. Upper bounds are calculated as
+    .. math::
+        ub = min + mult * dni_extra * cos( solar_zenith)^exp
+
+    Parameters
+    ----------
+    solar_zenith : Series
+        Solar zenith angle in degrees
+    dni_extra : Series
+        Extraterrestrial normal irradiance in W/m^2
+    ghi : Series or None, default None
+        Global horizontal irradiance in W/m^2
+    dhi : Series or None, default None
+        Diffuse horizontal irradiance in W/m^2
+    dni : Series or None, default None
+        Direct normal irradiance in W/m^2
+    limits : dict, default QCRAD_LIMITS
+        for keys 'ghi_ub', 'dhi_ub', 'dni_ub', value is a dict with
+        keys {'mult', 'exp', 'min'}. For keys 'ghi_lb', 'dhi_lb', 'dni_lb',
+        value is a float.
+
+    Returns
+    -------
+    ghi_limit_flag : Series or None, default None
+        True if value passes physically-possible test
+    dhi_limit_flag : Series or None, default None
+    dhi_limit_flag : Series or None, default None
+
+    References
+    ----------
+    [1] C. N. Long and Y. Shi, An Automated Quality Assessment and Control
+        Algorithm for Surface Radiation Measurements, The Open Atmospheric
+        Science Journal 2, pp. 23-37, 2008.
+    '''
+    if not limits:
+        limits = QCRAD_LIMITS
+
+    if ghi is not None:
+        ghi_limit_flag = check_ghi_limits(ghi, solar_zenith, dni_extra,
+                                                limits=limits)
+    else:
+        ghi_limit_flag = None
+
+    if dhi is not None:
+        dhi_limit_flag = check_dhi_limits(dhi, solar_zenith, dni_extra,
+                                                limits=limits)
+    else:
+        dhi_limit_flag = None
+
+    if dni is not None:
+        dni_limit_flag = check_dni_limits(dni, solar_zenith, dni_extra,
+                                                limits=limits)
+    else:
+        dni_limit_flag = None
+
+    return ghi_limit_flag, dhi_limit_flag, dni_limit_flag
+
+
+def _get_bounds(bounds):
+    return (bounds['ghi_bounds'][0], bounds['ghi_bounds'][1],
+            bounds['zenith_bounds'][0], bounds['zenith_bounds'][1],
+            bounds['ratio_bounds'][0], bounds['ratio_bounds'][1])
+
+
+def _check_irrad_ratio(ratio, ghi, sza, bounds):
+    # unpack bounds dict
+    ghi_lb, ghi_ub, sza_lb, sza_ub, ratio_lb, ratio_ub = _get_bounds(bounds)
+    # for zenith set lb_ge to handle edge cases, e.g., zenith=0
+    return ((_check_limits(sza, lb=sza_lb, ub=sza_ub, lb_ge=True)) &
+            (_check_limits(ghi, lb=ghi_lb, ub=ghi_ub)) &
+            (_check_limits(ratio, lb=ratio_lb, ub=ratio_ub)))
+
+
+def check_irradiance_consistency(ghi, solar_zenith, dni_extra, dhi, dni,
+                                       param=None):
+    '''
+    Checks consistency of GHI, DHI and DNI. Not valid for night time.
+
+    Parameters
+    ----------
+    ghi : Series
+        Global horizontal irradiance in W/m^2
+    solar_zenith : Series
+        Solar zenith angle in degrees
+    dni_extra : Series
+        Extraterrestrial normal irradiance in W/m^2
+    dhi : Series
+        Diffuse horizontal irradiance in W/m^2
+    dni : Series
+        Direct normal irradiance in W/m^2
+    param : dict
+        keys are 'ghi_ratio' and 'dhi_ratio'. For each key, value is a dict
+        with keys 'high_zenith' and 'low_zenith'; for each of these keys,
+        value is a dict with keys 'zenith_bounds', 'ghi_bounds', and
+        'ratio_bounds' and value is an ordered pair [lower, upper]
+        of float.
+
+    Returns
+    -------
+    consistent_components : Series
+        True if ghi, dhi and dni components are consistent.
+    diffuse_ratio_limit : Series
+        True if diffuse to ghi ratio passes limit test.
+
+    References
+    ----------
+    [1] C. N. Long and Y. Shi, An Automated Quality Assessment and Control
+        Algorithm for Surface Radiation Measurements, The Open Atmospheric
+        Science Journal 2, pp. 23-37, 2008.
+    '''
+
+    if not param:
+        param = QCRAD_CONSISTENCY
+
+    # sum of components
+    component_sum = dni * cosd(solar_zenith) + dhi
+    ghi_ratio = ghi / component_sum
+    dhi_ratio = dhi / ghi
+
+    bounds = param['ghi_ratio']
+    consistent_components = (
+        _check_irrad_ratio(ratio=ghi_ratio, ghi=component_sum,
+                           sza=solar_zenith, bounds=bounds['high_zenith']) |
+        _check_irrad_ratio(ratio=ghi_ratio, ghi=component_sum,
+                           sza=solar_zenith, bounds=bounds['low_zenith']))
+    consistent_components.name = 'consistent_components'
+
+    bounds = param['dhi_ratio']
+    diffuse_ratio_limit = (
+        _check_irrad_ratio(ratio=dhi_ratio, ghi=ghi, sza=solar_zenith,
+                           bounds=bounds['high_zenith']) |
+        _check_irrad_ratio(ratio=dhi_ratio, ghi=ghi, sza=solar_zenith,
+                           bounds=bounds['low_zenith']))
+    diffuse_ratio_limit.name = 'diffuse_ratio_limit'
+
+    return consistent_components, diffuse_ratio_limit

--- a/rdtools/qcrad.py
+++ b/rdtools/qcrad.py
@@ -176,7 +176,7 @@ def check_dni_limits(dni, solar_zenith, dni_extra, limits=None):
 
 
 def check_irradiance_limits(solar_zenith, dni_extra, ghi=None, dhi=None,
-                                  dni=None, limits=None):
+                            dni=None, limits=None):
     '''
     Tests for physical limits on GHI, DHI or DNI using the QCRad criteria.
 
@@ -255,7 +255,7 @@ def _check_irrad_ratio(ratio, ghi, sza, bounds):
 
 
 def check_irradiance_consistency(ghi, solar_zenith, dni_extra, dhi, dni,
-                                       param=None):
+                                 param=None):
     '''
     Checks consistency of GHI, DHI and DNI. Not valid for night time.
 

--- a/rdtools/test/qcrad_test.py
+++ b/rdtools/test/qcrad_test.py
@@ -97,7 +97,7 @@ def test_check_dni_limits(irradiance):
                                      expected['dni_extra'])
     assert_series_equal(dni_out, dni_out_expected)
 
-def test_check_irradiance_consistency_QCRad(irradiance):
+def test_check_irradiance_consistency(irradiance):
     expected = irradiance
     cons_comp, diffuse = qcrad.check_irradiance_consistency(
         expected['ghi'], expected['solar_zenith'], expected['dni_extra'],

--- a/rdtools/test/qcrad_test.py
+++ b/rdtools/test/qcrad_test.py
@@ -1,0 +1,103 @@
+import unittest
+import pandas as pd
+import numpy as np
+from rdtools import qcrad
+
+class QCRadTestCase(unittest.TestCase):
+
+    def setUp(self):
+        output = pd.DataFrame(
+        columns=['ghi', 'dhi', 'dni', 'solar_zenith', 'dni_extra',
+                 'ghi_limit_flag', 'dhi_limit_flag', 'dni_limit_flag',
+                 'consistent_components', 'diffuse_ratio_limit'],
+        data=np.array([[-100, 100, 100, 30, 1370, 0, 1, 1, 0, 0],
+                       [100, -100, 100, 30, 1370, 1, 0, 1, 0, 0],
+                       [100, 100, -100, 30, 1370, 1, 1, 0, 0, 1],
+                       [1000, 100, 900, 0, 1370, 1, 1, 1, 1, 1],
+                       [1000, 200, 800, 15, 1370, 1, 1, 1, 1, 1],
+                       [1000, 200, 800, 60, 1370, 0, 1, 1, 0, 1],
+                       [1000, 300, 850, 80, 1370, 0, 0, 1, 0, 1],
+                       [1000, 500, 800, 90, 1370, 0, 0, 1, 0, 1],
+                       [500, 100, 1100, 0, 1370, 1, 1, 1, 0, 1],
+                       [1000, 300, 1200, 0, 1370, 1, 1, 1, 0, 1],
+                       [500, 600, 100, 60, 1370, 1, 1, 1, 0, 0],
+                       [500, 600, 400, 80, 1370, 0, 0, 1, 0, 0],
+                       [500, 500, 300, 80, 1370, 0, 0, 1, 1, 1],
+                       [0, 0, 0, 93, 1370, 1, 1, 1, 0, 0]]))
+        dtypes = ['float64', 'float64', 'float64', 'float64', 'float64',
+                  'bool', 'bool', 'bool', 'bool', 'bool']
+        for (col, typ) in zip(output.columns, dtypes):
+            output[col] = output[col].astype(typ)
+
+        self.irradiance_QCRad = output
+
+    def test_check_irradiance_limits(self):
+        ghi_limits, dhi_limits, dni_limits = qcrad.check_irradiance_limits(
+            self.irradiance_QCRad['solar_zenith'],
+            self.irradiance_QCRad['dni_extra'],
+            ghi=self.irradiance_QCRad['ghi'])
+
+        self.assertListEqual(
+            ghi_limits.tolist(),
+            self.irradiance_QCRad['ghi_limit_flag'].tolist()
+        )
+        self.assertIsNone(dhi_limits)
+        self.assertIsNone(dni_limits)
+
+        ghi_limits, dhi_limits, dni_limits = qcrad.check_irradiance_limits(
+            self.irradiance_QCRad['solar_zenith'],
+            self.irradiance_QCRad['dni_extra'],
+            ghi=self.irradiance_QCRad['ghi'],
+            dhi=self.irradiance_QCRad['dhi'],
+            dni=self.irradiance_QCRad['dni']
+        )
+        self.assertListEqual(
+            dhi_limits.tolist(),
+            self.irradiance_QCRad['dhi_limit_flag'].tolist()
+        )
+        self.assertListEqual(
+            dni_limits.tolist(),
+            self.irradiance_QCRad['dni_limit_flag'].tolist()
+        )
+
+        ghi_limits, dhi_limits, dni_limits = qcrad.check_irradiance_limits(
+            self.irradiance_QCRad['solar_zenith'],
+            self.irradiance_QCRad['dni_extra']
+        )
+        self.assertIsNone(ghi_limits)
+        self.assertIsNone(dni_limits)
+        self.assertIsNone(dhi_limits)
+
+    def test_check_ghi_limits(self):
+        expected = self.irradiance_QCRad
+        ghi_out_expected = expected['ghi_limit_flag']
+        ghi_out = qcrad.check_ghi_limits(expected['ghi'],
+                                           expected['solar_zenith'],
+                                           expected['dni_extra'])
+        self.assertListEqual(ghi_out.tolist(), ghi_out_expected.tolist())
+
+    def test_check_dhi_limits(self):
+        expected = self.irradiance_QCRad
+        dhi_out_expected = expected['dhi_limit_flag']
+        dhi_out = qcrad.check_dhi_limits(expected['dhi'],
+                                           expected['solar_zenith'],
+                                           expected['dni_extra'])
+        self.assertListEqual(dhi_out.tolist(), dhi_out_expected.tolist())
+
+    def test_check_dni_limits(self):
+        expected = self.irradiance_QCRad
+        dni_out_expected = expected['dni_limit_flag']
+        dni_out = qcrad.check_dni_limits(expected['dni'],
+                                           expected['solar_zenith'],
+                                           expected['dni_extra'])
+        self.assertListEqual(dni_out.tolist(), dni_out_expected.tolist())
+
+    def test_check_irradiance_consistency_QCRad(self):
+        expected = self.irradiance_QCRad
+        cons_comp, diffuse = qcrad.check_irradiance_consistency(
+            expected['ghi'], expected['solar_zenith'], expected['dni_extra'],
+            expected['dhi'], expected['dni'])
+        self.assertListEqual(cons_comp.tolist(),
+                             expected['consistent_components'].tolist())
+        self.assertListEqual(diffuse.tolist(),
+                             expected['diffuse_ratio_limit'].tolist())


### PR DESCRIPTION
Adds data-quality checks from [solarforecastarbiter](https://github.com/SolarArbiter/solarforecastarbiter-core) to the RdTools filtering module. There are two main features added in this PR:
* filtering stale data (periods where the value has not changed) and interpolated data (looks for periods of linear interpolation)
* Validation of irradiance observations using the QCRad algorithm