### PR TITLE
update DKASC data link in example notebook on master

### DIFF
--- a/docs/degradation_example.ipynb
+++ b/docs/degradation_example.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "Note this example was run with data downloaded on Sept. 28, 2018. An older version of the data gave different sensor-based results. If you have an older version of the data and are getting different results, please try redownloading the data.\n",
     "\n",
-    "http://dkasolarcentre.com.au/historical-data/download"
+    "http://dkasolarcentre.com.au/download?location=alice-springs"
    ]
   },
   {


### PR DESCRIPTION
#177 brought up that the link to the desert knowledge dataset is broken.  I checked out the new data file and everything is the same, just the url to get it changed.  This PR is to master, should update development too. 

Do we want to add a note in the notebook saying "by the way the URL changed" or anything?