### PR TITLE
Include LICENSE file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include versioneer.py
 include rdtools/_version.py
 include rdtools/data/*
+include LICENSE


### PR DESCRIPTION
This adds the license file to the source distribution so that it gets packages along with the library itself on pypi and such.  We decided offline that no other files (docs, e.g.) need to be included at this point. Note that the "standard" files like setup.py and README.md are automatically included. 

`python setup.py sdist` will create a tar file so you can check what files get included in the distribution. 