### PR TITLE
Fix test suite dtype error on Windows

### DIFF
--- a/rdtools/test/soiling_test.py
+++ b/rdtools/test/soiling_test.py
@@ -280,12 +280,12 @@ def test_annual_soiling_ratios(multi_year_profiles):
         [2019, 14.5, 11.431, 17.569]])
     expected = pd.DataFrame(data=expected_data,
         columns=['year', 'soiling_ratio_median', 'soiling_ratio_low', 'soiling_ratio_high'])
-    expected['year'] = expected['year'].astype(np.int64)
+    expected['year'] = expected['year'].astype(int)
     
     srr_profiles, insolation = multi_year_profiles
     result = annual_soiling_ratios(srr_profiles, insolation)
 
-    pd.testing.assert_frame_equal(result, expected)
+    pd.testing.assert_frame_equal(result, expected, check_dtype=False)
 
 
 def test_annual_soiling_ratios_confidence_interval(multi_year_profiles):
@@ -293,12 +293,12 @@ def test_annual_soiling_ratios_confidence_interval(multi_year_profiles):
         [2019, 14.5, 10.225, 18.775]])
     expected = pd.DataFrame(data=expected_data,
         columns=['year', 'soiling_ratio_median', 'soiling_ratio_low', 'soiling_ratio_high'])
-    expected['year'] = expected['year'].astype(np.int64)
+    expected['year'] = expected['year'].astype(int)
 
     srr_profiles, insolation = multi_year_profiles
     result = annual_soiling_ratios(srr_profiles, insolation, confidence_level=95)
 
-    pd.testing.assert_frame_equal(result, expected)
+    pd.testing.assert_frame_equal(result, expected, check_dtype=False)
 
 
 def test_annual_soiling_ratios_warning(multi_year_profiles):

--- a/rdtools/test/soiling_test.py
+++ b/rdtools/test/soiling_test.py
@@ -280,7 +280,7 @@ def test_annual_soiling_ratios(multi_year_profiles):
         [2019, 14.5, 11.431, 17.569]])
     expected = pd.DataFrame(data=expected_data,
         columns=['year', 'soiling_ratio_median', 'soiling_ratio_low', 'soiling_ratio_high'])
-    expected['year'] = expected['year'].astype(int)
+    expected['year'] = expected['year'].astype(np.int64)
     
     srr_profiles, insolation = multi_year_profiles
     result = annual_soiling_ratios(srr_profiles, insolation)
@@ -293,7 +293,7 @@ def test_annual_soiling_ratios_confidence_interval(multi_year_profiles):
         [2019, 14.5, 10.225, 18.775]])
     expected = pd.DataFrame(data=expected_data,
         columns=['year', 'soiling_ratio_median', 'soiling_ratio_low', 'soiling_ratio_high'])
-    expected['year'] = expected['year'].astype(int)
+    expected['year'] = expected['year'].astype(np.int64)
 
     srr_profiles, insolation = multi_year_profiles
     result = annual_soiling_ratios(srr_profiles, insolation, confidence_level=95)


### PR DESCRIPTION
- [x] Code changes are covered by tests
- ~New functions added to `__init__.py`~
- ~API.rst is up to date, along with other sphinx docs pages~
- ~Example notebooks are rerun and differences in results scrutinized~
- ~Updated changelog~

Apparently the default long int width is 32 bits on 64-bit Windows but 64 bits on the other main OSs.  That causes a couple tests to fail when I run the test suite locally on Windows (the package returns int64 but the expected values are int32):

```python
>       pd.testing.assert_frame_equal(result, expected)
E       AssertionError: Attributes of DataFrame.iloc[:, 0] (column name="year") are different
E
E       Attribute "dtype" are different
E       [left]:  int64
E       [right]: int32
rdtools\test\soiling_test.py:288: AssertionError
```

This PR updates the dtypes in the failing tests to specify `np.int64` instead of the platform-dependent default `int`.  Reference: https://stackoverflow.com/a/36279549

Seems too minor to be worth mentioning in the changelog, but I'll add it if requested.