### PR TITLE
Add project urls to setup.py for pypi page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,12 @@ KEYWORDS = [
     'PV'
 ]
 
+PROJECT_URLS = {
+    "Bug Tracker": "https://github.com/NREL/rdtools/issues",
+    "Documentation": "https://rdtools.readthedocs.io/",
+    "Source Code": "https://github.com/NREL/rdtools",
+}
+
 setuptools_kwargs = {
     'zip_safe': False,
     'scripts': [],
@@ -114,5 +120,6 @@ setup(name=DISTNAME,
       maintainer_email=MAINTAINER_EMAIL,
       license=LICENSE,
       url=URL,
+      project_urls=PROJECT_URLS,
       classifiers=CLASSIFIERS,
       **setuptools_kwargs)


### PR DESCRIPTION
- ~Code changes are covered by tests~
- ~New functions added to `__init__.py`~
- ~API.rst is up to date, along with other sphinx docs pages~
- ~Example notebooks are rerun and differences in results scrutinized~
- ~Updated changelog~

PyPI can be configured to display various URLs through `setup.py` ([docs](https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls)).  Here's an [example](https://pypi.org/project/pandas/):

![image](https://user-images.githubusercontent.com/57452607/101953847-59b53080-3bb8-11eb-8ccc-fcc88206c003.png)

I'm not sure where the logic for matching icons to text (the dict keys) is documented, if anywhere, so I'm just copying pandas's descriptions.  One thing to note:  apparently the display order on pypi.org is reversed from the dictionary order here (see https://github.com/pypa/warehouse/issues/3097). 