### PR TITLE
Add python 3.9 to test matrix

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         env: [
           '-r requirements.txt .[test]',
           '-r requirements-min.txt .[test]',
@@ -19,6 +19,9 @@ jobs:
             env: '-r requirements-min.txt .[test]'
           - python-version: 3.8
             env: '-r requirements-min.txt .[test]'
+          - python-version: 3.9
+            env: '-r requirements-min.txt .[test]'
+            env: '-r requirements.txt .[test]'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,6 +21,7 @@ jobs:
             env: '-r requirements-min.txt .[test]'
           - python-version: 3.9
             env: '-r requirements-min.txt .[test]'
+          - python-version: 3.9
             env: '-r requirements.txt .[test]'
 
     steps:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,8 +21,6 @@ jobs:
             env: '-r requirements-min.txt .[test]'
           - python-version: 3.9
             env: '-r requirements-min.txt .[test]'
-          - python-version: 3.9
-            env: '-r requirements.txt .[test]'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install ${{ matrix.env }}
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install ${{ matrix.env }}
     - name: Test with pytest ${{ matrix.env }}
       run: |

--- a/docs/sphinx/source/changelog/v2.0.5.rst
+++ b/docs/sphinx/source/changelog/v2.0.5.rst
@@ -27,7 +27,7 @@ Documentation
 
 Requirements
 ------------
-* Update ``requirements.txt`` versions for numpy, scipy, pandas,
+* Update ``requirements.txt`` versions for numpy, scipy, pandas, h5py
   and statsmodels to versions that have wheels available for python
   3.6-3.9. Note that the minimum versions are unchanged. (:pull:`249`).
 

--- a/docs/sphinx/source/changelog/v2.0.5.rst
+++ b/docs/sphinx/source/changelog/v2.0.5.rst
@@ -18,12 +18,16 @@ Bug fixes
 
 Testing
 -------
+* Add Python 3.9 to CI testing (:pull:`249`)
 
 Documentation
 -------------
 
 Requirements
 ------------
+* Update ``requirements.txt`` versions for numpy, scipy, pandas,
+  and statsmodels to versions that have wheels available for python
+  3.6-3.9. Note that the minimum versions are unchanged. (:pull:`249`).
 
 Example Updates
 ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ cycler==0.10.0
 h5py==2.10.0
 kiwisolver==1.2.0
 matplotlib==3.3.2
-numpy==1.17.3
-pandas==1.1.0
+numpy==1.19.4
+pandas==1.1.3
 patsy==0.5.1
 pvlib==0.7.1
 pyparsing==2.4.7
 python-dateutil==2.8.1
 pytz==2019.3
-scipy==1.3.2
+scipy==1.5.4
 six==1.14.0
-statsmodels==0.11.1
+statsmodels==0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cycler==0.10.0
-h5py==2.10.0
+h5py==3.1.0
 kiwisolver==1.2.0
 matplotlib==3.3.2
 numpy==1.19.4

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Topic :: Scientific/Engineering',
 ]
 


### PR DESCRIPTION
- [ ] Code changes are covered by tests
- [ ] New functions added to `__init__.py`
- [ ] API.rst is up to date, along with other sphinx docs pages
- [x] Example notebooks are rerun and differences in results scrutinized
- [x] Updated changelog

Closes #228.  ~Only using with `--upgrade-strategy=eager` for now because I'm guessing many dependency versions in `requirements.txt` won't have 3.9 wheels on pypi.~