### PR TITLE
Fix pandas 1.2.0 test suite errors

### DIFF
--- a/docs/sphinx/source/changelog/v2.0.5.rst
+++ b/docs/sphinx/source/changelog/v2.0.5.rst
@@ -18,6 +18,7 @@ Bug fixes
 
 Testing
 -------
+* Fix test suite error raised when using pandas 1.2.0 (:pull:`251`)
 
 Documentation
 -------------

--- a/rdtools/test/soiling_test.py
+++ b/rdtools/test/soiling_test.py
@@ -204,7 +204,7 @@ def test_soiling_srr_recenter_false(normalized_daily, insolation):
 
 def test_soiling_srr_negative_step(normalized_daily, insolation):
     stepped_daily = normalized_daily.copy()
-    stepped_daily.iloc[37:] = stepped_daily.iloc[25:] - 0.1
+    stepped_daily.iloc[37:] = stepped_daily.iloc[37:] - 0.1
 
     np.random.seed(1977)
     sr, sr_ci, soiling_info = soiling_srr(stepped_daily, insolation, reps=10)


### PR DESCRIPTION
- [ ] ~Code changes are covered by tests~
- [ ] ~New functions added to `__init__.py`~
- [ ] ~API.rst is up to date, along with other sphinx docs pages~
- [ ] ~Example notebooks are rerun and differences in results scrutinized~
- [x] Updated changelog

Fixes a failure @mdeceglie noticed in #249 that turned out to be related to the recent pandas release ([release notes](https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.2.0.html)).