### PR TITLE
Test suite warning clean-up

### DIFF
--- a/rdtools/test/analysis_chains_test.py
+++ b/rdtools/test/analysis_chains_test.py
@@ -262,8 +262,9 @@ def soiling_analysis_clearsky(soiling_parameters, cs_input):
     soiling_analysis = TrendAnalysis(**soiling_parameters)
     soiling_analysis.set_clearsky(**cs_input)
     np.random.seed(1977)
-    soiling_analysis.clearsky_analysis(analyses=['srr_soiling'],
-                                       srr_kwargs={'reps': 10})
+    with pytest.warns(UserWarning, match='20% or more of the daily data'):
+        soiling_analysis.clearsky_analysis(analyses=['srr_soiling'],
+                                           srr_kwargs={'reps': 10})
     return soiling_analysis
 
 

--- a/rdtools/test/energy_from_power_test.py
+++ b/rdtools/test/energy_from_power_test.py
@@ -32,7 +32,9 @@ def test_energy_from_power_max_timedelta_inference(power):
     expected = power.iloc[1:]*0.25
     expected.name = 'energy_Wh'
     expected.iloc[:2] = np.nan
-    result = energy_from_power(power.drop(power.index[1]))
+    match = 'Fraction of excluded data (.*) exceeded threshold'
+    with pytest.warns(UserWarning, match=match):
+        result = energy_from_power(power.drop(power.index[1]))
     pd.testing.assert_series_equal(result, expected)
 
 

--- a/rdtools/test/plotting_test.py
+++ b/rdtools/test/plotting_test.py
@@ -57,6 +57,7 @@ def test_degradation_summary_plots(degradation_info):
     # test defaults
     result = degradation_summary_plots(yoy_rd, yoy_ci, yoy_info, power)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')
 
 
 def test_degradation_summary_plots_kwargs(degradation_info):
@@ -76,6 +77,7 @@ def test_degradation_summary_plots_kwargs(degradation_info):
     result = degradation_summary_plots(yoy_rd, yoy_ci, yoy_info, power,
                                        **kwargs)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')
 
 
 @pytest.fixture()
@@ -102,6 +104,7 @@ def test_soiling_monte_carlo_plot(soiling_normalized_daily, soiling_info):
     # test defaults
     result = soiling_monte_carlo_plot(soiling_info, soiling_normalized_daily)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')
 
 
 def test_soiling_monte_carlo_plot_kwargs(soiling_normalized_daily, soiling_info):
@@ -118,12 +121,14 @@ def test_soiling_monte_carlo_plot_kwargs(soiling_normalized_daily, soiling_info)
     result = soiling_monte_carlo_plot(soiling_info, soiling_normalized_daily,
                                       **kwargs)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')
 
 
 def test_soiling_interval_plot(soiling_normalized_daily, soiling_info):
     # test defaults
     result = soiling_interval_plot(soiling_info, soiling_normalized_daily)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')
 
 
 def test_soiling_interval_plot_kwargs(soiling_normalized_daily, soiling_info):
@@ -139,12 +144,14 @@ def test_soiling_interval_plot_kwargs(soiling_normalized_daily, soiling_info):
     result = soiling_interval_plot(soiling_info, soiling_normalized_daily,
                                    **kwargs)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')
 
 
 def test_soiling_rate_histogram(soiling_info):
     # test defaults
     result = soiling_rate_histogram(soiling_info)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')
 
 
 def test_soiling_rate_histogram_kwargs(soiling_info):
@@ -154,6 +161,7 @@ def test_soiling_rate_histogram_kwargs(soiling_info):
     )
     result = soiling_rate_histogram(soiling_info, **kwargs)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')
 
 
 def test_availability_summary_plots(availability_analysis_object):
@@ -163,6 +171,7 @@ def test_availability_summary_plots(availability_analysis_object):
         aa.energy_cumulative, aa.energy_expected_rescaled,
         aa.outage_info)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')
 
 
 def test_availability_summary_plots_empty(availability_analysis_object):
@@ -174,3 +183,4 @@ def test_availability_summary_plots_empty(availability_analysis_object):
         aa.energy_cumulative, aa.energy_expected_rescaled,
         empty)
     assert_isinstance(result, plt.Figure)
+    plt.close('all')

--- a/rdtools/test/soiling_test.py
+++ b/rdtools/test/soiling_test.py
@@ -115,7 +115,7 @@ def test_soiling_srr_dayscale(soiling_normalized_daily, soiling_insolation):
     with pytest.raises(NoValidIntervalError):
         np.random.seed(1977)
         sr, sr_ci, soiling_info = soiling_srr(soiling_normalized_daily, soiling_insolation,
-                                              confidence_level=68.2, reps=10, day_scale=90)
+                                              confidence_level=68.2, reps=10, day_scale=91)
 
 
 def test_soiling_srr_clean_threshold(soiling_normalized_daily, soiling_insolation):

--- a/rdtools/test/soiling_test.py
+++ b/rdtools/test/soiling_test.py
@@ -51,7 +51,7 @@ def test_soiling_srr(soiling_normalized_daily, soiling_insolation, soiling_times
                                      'inferred_start_loss', 'inferred_end_loss',
                                      'length', 'valid']]
     pd.testing.assert_series_equal(expected_means, soiling_info['soiling_interval_summary'].mean(),
-                                   check_exact=False, check_less_precise=6)
+                                   check_exact=False)
 
     # Check soiling_info['soiling_ratio_perfect_clean']
     pd.testing.assert_index_equal(soiling_info['soiling_ratio_perfect_clean'].index, soiling_times,

--- a/rdtools/test/soiling_test.py
+++ b/rdtools/test/soiling_test.py
@@ -50,8 +50,8 @@ def test_soiling_srr(soiling_normalized_daily, soiling_insolation, soiling_times
     expected_means = expected_means[['soiling_rate', 'soiling_rate_low', 'soiling_rate_high',
                                      'inferred_start_loss', 'inferred_end_loss',
                                      'length', 'valid']]
-    pd.testing.assert_series_equal(expected_means, soiling_info['soiling_interval_summary'].mean(),
-                                   check_exact=False)
+    actual_means = soiling_info['soiling_interval_summary'][expected_means.index].mean()
+    pd.testing.assert_series_equal(expected_means, actual_means, check_exact=False)
 
     # Check soiling_info['soiling_ratio_perfect_clean']
     pd.testing.assert_index_equal(soiling_info['soiling_ratio_perfect_clean'].index, soiling_times,

--- a/rdtools/test/soiling_test.py
+++ b/rdtools/test/soiling_test.py
@@ -72,9 +72,8 @@ def test_soiling_srr_consecutive_invalid(soiling_normalized_daily, soiling_insol
                                          soiling_times, method, expected_sr):
     reps = 10
     np.random.seed(1977)
-    sr, sr_ci, soiling_info = soiling_srr(soiling_normalized_daily, soiling_insolation,
-                                          reps=reps, max_relative_slope_error=20.0,
-                                          method=method)
+    sr, sr_ci, soiling_info = soiling_srr(soiling_normalized_daily, soiling_insolation, reps=reps,
+                                          max_relative_slope_error=20.0, method=method)
     assert expected_sr == pytest.approx(sr, abs=1e-6),\
         f'Soiling ratio different from expected value for {method} with consecutive invalid intervals'  # noqa: E501
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,5 @@ test = pytest
 
 [tool:pytest]
 addopts = --verbose
+filterwarnings =
+    ignore:The .* module is currently experimental:UserWarning:rdtools

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,7 @@ test = pytest
 
 [tool:pytest]
 addopts = --verbose
+# suppress warnings.  syntax is "action:message:category:module:lineno"
+# https://docs.python.org/3/library/warnings.html#the-warnings-filter
 filterwarnings =
     ignore:The .* module is currently experimental:UserWarning:rdtools


### PR DESCRIPTION
- ~Code changes are covered by tests~
- ~New functions added to `__init__.py`~
- ~API.rst is up to date, along with other sphinx docs pages~
- ~Example notebooks are rerun and differences in results scrutinized~
- [ ] Updated changelog

Cleans up pytest output by (1) suppressing expected warnings like the experimental module warnings and (2) solving whatever the warning was about for unexpected warnings.

Note that our minimum requirements tests are always going to dump a bunch of deprecation warnings, but at least the others are cleaned up a bit.  