### PR TITLE
Update TrendAnalysis notebook to avoid filter index mismatch warning

### DIFF
--- a/docs/TrendAnalysis_example_pvdaq4.ipynb
+++ b/docs/TrendAnalysis_example_pvdaq4.ipynb
@@ -745,12 +745,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ta_stuck_filter.filter_params['ad_hoc_filter'] = (\n",
-    "                                                  filter_stuck_values(df['power']) & \n",
-    "                                                  filter_stuck_values(df['poa']) &\n",
-    "                                                  filter_stuck_values(df['Tamb']) &\n",
-    "                                                  filter_stuck_values(df['wind_speed'])\n",
-    "                                                 )"
+    "stuck_filter =  (\n",
+    "                  filter_stuck_values(df['power']) & \n",
+    "                  filter_stuck_values(df['poa']) &\n",
+    "                  filter_stuck_values(df['Tamb']) &\n",
+    "                  filter_stuck_values(df['wind_speed'])\n",
+    "                 )\n",
+    "\n",
+    "# reindex onto the same index that will be used for the other filters\n",
+    "stuck_filter = stuck_filter.reindex(ta_stuck_filter.poa_global.index, fill_value=True)\n",
+    "\n",
+    "ta_stuck_filter.filter_params['ad_hoc_filter'] = stuck_filter"
    ]
   },
   {


### PR DESCRIPTION
This adds a few lines to the TrendAnalysis notebook to explicitly reindex the ad_hoc_filter and avoid a warning

- ~Code changes are covered by tests~
- ~New functions added to `__init__.py`~
- ~API.rst is up to date, along with other sphinx docs pages~
- [x] Example notebooks are rerun and differences in results scrutinized
- ~Updated changelog~