### PR TITLE
Support pvlib 0.9.x

### DIFF
--- a/docs/notebook_requirements.txt
+++ b/docs/notebook_requirements.txt
@@ -40,7 +40,6 @@ pyzmq==17.1.0
 qtconsole==4.3.1
 Send2Trash==1.5.0
 simplegeneric==0.8.1
-tables==3.6.1
 terminado==0.8.3
 testpath==0.3.1
 tornado==6.1

--- a/docs/sphinx/source/changelog/v2.1.0.rst
+++ b/docs/sphinx/source/changelog/v2.1.0.rst
@@ -64,8 +64,8 @@ Requirements
 * Installation (``setup.py``) now requires plotly, joblib, xgboost, tables, and scikit-learn
 * Update pinned versions of several dependencies in ``requirements.txt`` and
   ``docs/notebook_requirements.txt`` (:pull:`289`)
-
-* Add support for pvlib 0.9 (:pull:`290`)
+* Add support for pvlib 0.9 and remove the ``tables`` dependency added in
+  ``v2.1.0b0`` (:pull:`290`)
 
 
 Example Updates

--- a/docs/sphinx/source/changelog/v2.1.0.rst
+++ b/docs/sphinx/source/changelog/v2.1.0.rst
@@ -65,6 +65,8 @@ Requirements
 * Update pinned versions of several dependencies in ``requirements.txt`` and
   ``docs/notebook_requirements.txt`` (:pull:`289`)
 
+* Add support for pvlib 0.9 (:pull:`290`)
+
 
 Example Updates
 ---------------

--- a/rdtools/normalization.py
+++ b/rdtools/normalization.py
@@ -185,6 +185,11 @@ def sapm_dc_power(pvlib_pvsystem, met_data):
     speed. Effective irradiance and cell temperature are calculated with SAPM,
     and DC power with PVWatts.
 
+    .. warning::
+        The ``pvlib_pvsystem`` argument must be a ``pvlib.pvsystem.LocalizedPVSystem``
+        object, which is no longer available as of pvlib 0.9.0.  To use this function
+        you'll need to use an older version of pvlib.
+
     Parameters
     ----------
     pvlib_pvsystem : pvlib.pvsystem.LocalizedPVSystem
@@ -256,6 +261,11 @@ def normalize_with_sapm(energy, sapm_kws):
     ambient temperature, and wind speed.
 
     Energy timeseries and met_data timeseries can be different granularities.
+
+    .. warning::
+        The ``pvlib_pvsystem`` argument must be a ``pvlib.pvsystem.LocalizedPVSystem``
+        object, which is no longer available as of pvlib 0.9.0.  To use this function
+        you'll need to use an older version of pvlib.
 
     Parameters
     ----------

--- a/rdtools/test/conftest.py
+++ b/rdtools/test/conftest.py
@@ -38,6 +38,11 @@ def assert_isinstance(obj, klass):
     assert isinstance(obj, klass), f'got {type(obj)}, expected {klass}'
 
 
+requires_pvlib_below_090 = \
+    pytest.mark.skipif(parse_version(pvlib.__version__) > parse_version('0.8.1'),
+                       reason='requires pvlib <= 0.8.1')
+
+
 # %% Soiling fixtures
 
 @pytest.fixture()

--- a/rdtools/test/normalization_sapm_test.py
+++ b/rdtools/test/normalization_sapm_test.py
@@ -10,10 +10,11 @@ import pvlib
 from rdtools.normalization import normalize_with_sapm
 from rdtools.normalization import sapm_dc_power
 
-from conftest import fail_on_rdtools_version
+from conftest import fail_on_rdtools_version, requires_pvlib_below_090
 from rdtools._deprecation import rdtoolsDeprecationWarning
 
 
+@requires_pvlib_below_090
 class SapmNormalizationTestCase(unittest.TestCase):
     ''' Unit tests for energy normalization module. '''
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,9 +2,10 @@ h5py==2.7.1
 matplotlib==3.0.0
 numpy==1.15
 pandas==0.23.0
-pvlib==0.9.0
-scipy==1.2.0  # 1.2.0 is minimum for pvlib 0.9.0
+pvlib==0.7.0
+scipy==0.19.1
 statsmodels==0.8.0
+tables==3.4.2
 numexpr==2.7.1  # https://github.com/pydata/numexpr/issues/369
 plotly==4.0.0
 joblib==0.16.0

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,10 +2,9 @@ h5py==2.7.1
 matplotlib==3.0.0
 numpy==1.15
 pandas==0.23.0
-pvlib==0.7.0
+pvlib==0.9.0
 scipy==0.19.1
 statsmodels==0.8.0
-tables==3.4.2
 numexpr==2.7.1  # https://github.com/pydata/numexpr/issues/369
 plotly==4.0.0
 joblib==0.16.0

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,7 +3,7 @@ matplotlib==3.0.0
 numpy==1.15
 pandas==0.23.0
 pvlib==0.9.0
-scipy==0.19.1
+scipy==1.2.0  # 1.2.0 is minimum for pvlib 0.9.0
 statsmodels==0.8.0
 numexpr==2.7.1  # https://github.com/pydata/numexpr/issues/369
 plotly==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ numpy==1.19.5
 pandas==1.1.3
 patsy==0.5.1
 Pillow==8.2.0
-pvlib==0.7.1
+pvlib==0.9.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
 pytz==2019.3
@@ -21,6 +21,5 @@ statsmodels==0.12.1
 plotly==4.10.0
 joblib==0.16.0
 xgboost==1.3.3
-tables==3.6.1
 scikit-learn==0.24.1
 urllib3==1.26.4

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,6 @@ EXTRAS_REQUIRE = {
         'sphinx==3.2',
         'nbsphinx==0.8.5',
         'nbsphinx-link==1.3.0',
-        'pandas==0.23.0',
-        'pvlib==0.7.1',
         'sphinx_rtd_theme==0.5.2',
         'ipython',
         # sphinx-gallery used indirectly for nbsphinx thumbnail galleries; see:

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,7 @@ INSTALL_REQUIRES = [
     'plotly>=4.0.0',
     'joblib >= 0.16.0',
     'xgboost >= 1.3.3',
-    'pvlib >= 0.7.0, <0.10.0',
-    'tables >= 3.4.2',
+    'pvlib >= 0.9.0, <0.10.0',
     'scikit-learn >= 0.22.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ INSTALL_REQUIRES = [
     'plotly>=4.0.0',
     'joblib >= 0.16.0',
     'xgboost >= 1.3.3',
-    'pvlib >= 0.9.0, <0.10.0',
+    'pvlib >= 0.7.0, <0.10.0',
     'scikit-learn >= 0.22.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ INSTALL_REQUIRES = [
     'plotly>=4.0.0',
     'joblib >= 0.16.0',
     'xgboost >= 1.3.3',
-    'pvlib >= 0.7.0, <0.9.0',
+    'pvlib >= 0.7.0, <0.10.0',
     'tables >= 3.4.2',
     'scikit-learn >= 0.22.0',
 ]


### PR DESCRIPTION
- [ ] Code changes are covered by tests
- [ ] New functions added to `__init__.py`
- [ ] API.rst is up to date, along with other sphinx docs pages
- [x] Example notebooks are rerun and differences in results scrutinized
- [x] Updated changelog

Extra to-do:
- [x] Add note to SAPM functions saying an older pvlib is needed

`pvlib==0.9.0` is up on pypi as of today.  Our current setup.py specifies `'pvlib >= 0.7.0, <0.9.0'`, but it'd be nice to support the `0.9.x` series if it's easy.  I think there are only two relevant changes (but we'll see what the CI has to say):
- The SAPM normalization functionality won't work on 0.9.0 because `LocalizedPVSystem` is removed
- For clear-sky modeling, the `tables` dependency is removed and `h5py` is added in its place.  Note that `h5py` is required for pvlib 0.9.0 whereas `tables` was optional for previous versions. 