### PR TITLE
Create github action to check consistency of requirements.txt and notebook_requirements.txt

### DIFF
--- a/.github/workflows/requirements.yaml
+++ b/.github/workflows/requirements.yaml
@@ -1,0 +1,22 @@
+name: requirements
+
+on: [pull_request, push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install ${{ matrix.env }}
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install -r requirements.txt -r docs/notebook_requirements.txt
+    - name: Import RdTools 
+      run: |
+        python -c "import rdtools"

--- a/.github/workflows/requirements.yaml
+++ b/.github/workflows/requirements.yaml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Install ${{ matrix.env }}
+    - name: Install notebook environment
       run: |
         python -m pip install --upgrade pip wheel
         pip install -r requirements.txt -r docs/notebook_requirements.txt

--- a/.github/workflows/requirements.yaml
+++ b/.github/workflows/requirements.yaml
@@ -5,7 +5,11 @@ on: [pull_request, push]
 jobs:
   requirements:
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/requirements.yaml
+++ b/.github/workflows/requirements.yaml
@@ -3,7 +3,7 @@ name: requirements
 on: [pull_request, push]
 
 jobs:
-  build:
+  requirements:
 
     runs-on: ubuntu-latest
 
@@ -19,4 +19,4 @@ jobs:
         pip install -r requirements.txt -r docs/notebook_requirements.txt
     - name: Import RdTools 
       run: |
-        python -c "import rdtools"
+        python -c "import rdtools"  # note: this imports from pwd, not site-packages

--- a/docs/sphinx/source/changelog.rst
+++ b/docs/sphinx/source/changelog.rst
@@ -1,6 +1,7 @@
 RdTools Change Log
 ==================
 
+.. include:: changelog/v2.1.1.rst
 .. include:: changelog/v2.1.0.rst
 .. include:: changelog/v2.0.6.rst
 .. include:: changelog/v2.0.5.rst

--- a/docs/sphinx/source/changelog/v2.1.1.rst
+++ b/docs/sphinx/source/changelog/v2.1.1.rst
@@ -1,0 +1,6 @@
+**************************
+v2.1.1 (November 30, 2021)
+**************************
+
+This patch release temporarily requires `xgboost < 1.5.0`.  A future update
+will allow a wider version range.  (:issue:`301`, :pull:`297`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ joblib==0.16.0
 kiwisolver==1.2.0
 matplotlib==3.3.4
 numpy==1.19.5
-pandas==1.1.3
+pandas==0.21.0
 patsy==0.5.1
 Pillow==8.3.2
 plotly==4.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ python-dateutil==2.8.1
 pytz==2019.3
 requests==2.25.1
 scikit-learn==0.24.1
-scipy==1.1.0
+scipy==1.5.4
 six==1.14.0
 statsmodels==0.12.1
 urllib3==1.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ joblib==0.16.0
 kiwisolver==1.2.0
 matplotlib==3.3.4
 numpy==1.19.5
-pandas==0.21.0
+pandas==1.1.3
 patsy==0.5.1
 Pillow==8.3.2
 plotly==4.10.0
@@ -18,7 +18,7 @@ python-dateutil==2.8.1
 pytz==2019.3
 requests==2.25.1
 scikit-learn==0.24.1
-scipy==1.5.4
+scipy==1.1.0
 six==1.14.0
 statsmodels==0.12.1
 urllib3==1.26.5

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ INSTALL_REQUIRES = [
     'h5py >= 2.7.1',
     'plotly>=4.0.0',
     'joblib >= 0.16.0',
-    'xgboost >= 1.3.3',
+    'xgboost >= 1.3.3, <1.5.0',
     'pvlib >= 0.7.0, <0.10.0',
     'scikit-learn >= 0.22.0',
 ]


### PR DESCRIPTION
- [x] Code changes are covered by tests
- [x] Code changes have been evaluated for compatibility/integration with TrendAnalysis
- [x] New functions added to `__init__.py`
- [x] API.rst is up to date, along with other sphinx docs pages
- [x] Example notebooks are rerun and differences in results scrutinized
- [x] Updated changelog

@mdeceglie suggested adding a job to verify the consistency of `requirements.txt` and `notebook_requirements.txt` to make it easier to review PRs from dependabot.  Note that consistency of `requirements.txt` is already checked by the pytest jobs, but currently no CI job uses `notebook_requirements.txt`.  Also note that dependabot does suggest updates to `notebook_requirements.txt`, not just `requirements.txt`, e.g. #288.  Maybe this job will become redundant if we ever get around to #270. 

I tested some inconsistent environments on my fork to see what failures look like; here are the corresponding jobs:
- inconsistent 1: https://github.com/kanderso-nrel/rdtools/runs/3737515003?check_suite_focus=true
- inconsistent 2: https://github.com/kanderso-nrel/rdtools/runs/3737560421?check_suite_focus=true
- consistent: https://github.com/kanderso-nrel/rdtools/runs/3737621395?check_suite_focus=true

Note that `inconsistent 1` requested a version of numpy without wheels for py 3.7, so it tried to compile it from source and it was that compilation that failed, not a consistency error, so it's not really relevant.  But `inconsistent 2` shows an actual consistency failure. 