### PR TITLE
Add CI notebook check using pytest-notebook

### DIFF
--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -14,7 +14,7 @@ jobs:
         ]
         notebook: [
           'TrendAnalysis_example_pvdaq4.ipynb',
-          'degradation_and_soiling_example_pvdaq4.ipynb',
+          'degradation_and_soiling_example_pvdaq_4.ipynb',
           'system_availability_example.ipynb',
           # we can't download the data file automatically, so skip the DKASC notebook
           # 'degradation_and_soiling_example.ipynb',

--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -6,26 +6,34 @@ jobs:
   notebook-check:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        notebook: [
-          'TrendAnalysis_example_pvdaq4.ipynb',
-          'degradation_and_soiling_example_pvdaq_4.ipynb',
-          'system_availability_example.ipynb',
-          # we can't download the data file automatically, so skip the DKASC notebook
-          # 'degradation_and_soiling_example.ipynb',
-        ]
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Install Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+
     - name: Install test environment
       run: |
         python -m pip install --upgrade pip wheel pytest-notebook==0.6.1
         pip install -r requirements.txt -r docs/notebook_requirements.txt .[test]
-    - name: Test with pytest-notebook ${{ matrix.env }}
-      run: |  # see setup.cfg for pytest-notebook configuration
-        pytest --nb-test-files --nb-exec-timeout=500 docs/${{ matrix.notebook }}
+
+    # test notebooks using pytest-notebook; see setup.cfg for configuration
+    # notes: 
+    # - better to run the notebooks in serial (instead of parallel jobs)
+    #   because the two PVDAQ4 notebooks might conflict when writing the pickle data file.
+    # - the PVDAQ4 notebooks have some slow cells and require a longer timeout
+    # - can't run the DKASC notebook here because it requires pre-downloaded data
+    - name: pytest-notebook: system_availability_example.ipynb
+      run: | 
+        pytest --nb-test-files docs/system_availability_example.ipynb
+
+    - name: pytest-notebook: TrendAnalysis_example_pvdaq4.ipynb
+      run: | 
+        pytest --nb-test-files --nb-exec-timeout=500 TrendAnalysis_example_pvdaq4.ipynb
+
+    - name: pytest-notebook: degradation_and_soiling_example_pvdaq_4.ipynb
+      run: | 
+        pytest --nb-test-files --nb-exec-timeout=500 degradation_and_soiling_example_pvdaq_4.ipynb

--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -8,10 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
-        env: [
-          '-r requirements.txt -r docs/notebook_requirements.txt .[test]',
-        ]
         notebook: [
           'TrendAnalysis_example_pvdaq4.ipynb',
           'degradation_and_soiling_example_pvdaq_4.ipynb',
@@ -22,15 +18,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install ${{ matrix.env }}
+        python-version: 3.7
+    - name: Install test environment
       run: |
-        python -m pip install --upgrade pip wheel
-        pip install ${{ matrix.env }}
-        pip install pytest-notebook==0.6.1
+        python -m pip install --upgrade pip wheel pytest-notebook==0.6.1
+        pip install -r requirements.txt -r docs/notebook_requirements.txt .[test]
     - name: Test with pytest-notebook ${{ matrix.env }}
       run: |  # see setup.cfg for pytest-notebook configuration
         pytest --nb-test-files --nb-exec-timeout=500 docs/${{ matrix.notebook }}

--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -4,6 +4,14 @@ on: [pull_request, push]
 
 jobs:
   notebook-check:
+    strategy:
+      matrix:
+        notebook-file: [
+          'system_availability_example.ipynb',
+          'TrendAnalysis_example_pvdaq4.ipynb',
+          'degradation_and_soiling_example_pvdaq_4.ipynb'
+          # can't run the DKASC notebook here because it requires pre-downloaded data
+        ]
 
     runs-on: ubuntu-latest
 
@@ -20,20 +28,7 @@ jobs:
         python -m pip install --upgrade pip wheel
         pip install -r requirements.txt -r docs/notebook_requirements.txt .[test]
 
-    # test notebooks using pytest-notebook; see setup.cfg for configuration
-    # notes: 
-    # - better to run the notebooks in serial (instead of parallel jobs)
-    #   because the two PVDAQ4 notebooks might conflict when writing the pickle data file.
-    # - the PVDAQ4 notebooks have some slow cells and require a longer timeout
-    # - can't run the DKASC notebook here because it requires pre-downloaded data
-    - name: pytest-notebook -- system_availability_example.ipynb
+    # test notebook using pytest-notebook; see setup.cfg for configuration
+    - name: pytest-notebook 
       run: | 
-        pytest --nb-test-files docs/system_availability_example.ipynb
-
-    - name: pytest-notebook -- TrendAnalysis_example_pvdaq4.ipynb
-      run: | 
-        pytest --nb-test-files --nb-exec-timeout=500 docs/TrendAnalysis_example_pvdaq4.ipynb
-
-    - name: pytest-notebook -- degradation_and_soiling_example_pvdaq_4.ipynb
-      run: | 
-        pytest --nb-test-files --nb-exec-timeout=500 docs/degradation_and_soiling_example_pvdaq_4.ipynb
+        pytest --nb-test-files --nb-exec-timeout=500 docs/${{ matrix.notebook-file }}

--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -1,0 +1,36 @@
+name: nbval
+
+on: [pull_request, push]
+
+jobs:
+  notebook-check:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+        env: [
+          '-r requirements.txt -r docs/notebook_requirements.txt .[test]',
+        ]
+        notebook: [
+          'TrendAnalysis_example_pvdaq4.ipynb',
+          'degradation_and_soiling_example_pvdaq4.ipynb',
+          'system_availability_example.ipynb',
+          # we can't download the data file automatically, so skip the DKASC notebook
+          # 'degradation_and_soiling_example.ipynb',
+        ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install ${{ matrix.env }}
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install ${{ matrix.env }}
+        pip install pytest-notebook==0.6.1
+    - name: Test with pytest-notebook ${{ matrix.env }}
+      run: |  # see setup.cfg for pytest-notebook configuration
+        pytest --nb-test-files --nb-exec-timeout=500 docs/${{ matrix.notebook }}

--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -32,8 +32,8 @@ jobs:
 
     - name: pytest-notebook -- TrendAnalysis_example_pvdaq4.ipynb
       run: | 
-        pytest --nb-test-files --nb-exec-timeout=500 TrendAnalysis_example_pvdaq4.ipynb
+        pytest --nb-test-files --nb-exec-timeout=500 docs/TrendAnalysis_example_pvdaq4.ipynb
 
     - name: pytest-notebook -- degradation_and_soiling_example_pvdaq_4.ipynb
       run: | 
-        pytest --nb-test-files --nb-exec-timeout=500 degradation_and_soiling_example_pvdaq_4.ipynb
+        pytest --nb-test-files --nb-exec-timeout=500 docs/degradation_and_soiling_example_pvdaq_4.ipynb

--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -26,14 +26,14 @@ jobs:
     #   because the two PVDAQ4 notebooks might conflict when writing the pickle data file.
     # - the PVDAQ4 notebooks have some slow cells and require a longer timeout
     # - can't run the DKASC notebook here because it requires pre-downloaded data
-    - name: pytest-notebook: system_availability_example.ipynb
+    - name: pytest-notebook -- system_availability_example.ipynb
       run: | 
         pytest --nb-test-files docs/system_availability_example.ipynb
 
-    - name: pytest-notebook: TrendAnalysis_example_pvdaq4.ipynb
+    - name: pytest-notebook -- TrendAnalysis_example_pvdaq4.ipynb
       run: | 
         pytest --nb-test-files --nb-exec-timeout=500 TrendAnalysis_example_pvdaq4.ipynb
 
-    - name: pytest-notebook: degradation_and_soiling_example_pvdaq_4.ipynb
+    - name: pytest-notebook -- degradation_and_soiling_example_pvdaq_4.ipynb
       run: | 
         pytest --nb-test-files --nb-exec-timeout=500 degradation_and_soiling_example_pvdaq_4.ipynb

--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -1,4 +1,4 @@
-name: nbval
+name: notebook-check
 
 on: [pull_request, push]
 

--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Install test environment
       run: |
-        python -m pip install --upgrade pip wheel pytest-notebook==0.6.1
+        python -m pip install --upgrade pip wheel
         pip install -r requirements.txt -r docs/notebook_requirements.txt .[test]
 
     # test notebooks using pytest-notebook; see setup.cfg for configuration

--- a/docs/notebook_requirements.txt
+++ b/docs/notebook_requirements.txt
@@ -22,7 +22,7 @@ jupyter-core==4.6.3
 jupyter==1.0.0
 MarkupSafe==1.1.1
 mistune==0.8.3
-nbconvert==6.1.0
+nbconvert==5.6.1
 nbformat==5.0.7
 notebook==6.4.1
 numexpr==2.7.3

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -132,6 +132,19 @@ specific details, you can run ``coverage html`` to generate a detailed HTML
 report at ``htmlcov/index.html`` to view in a browser.  
 
 
+Running the notebooks as tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Re-running the example notebooks to see if their outputs have changed is
+another good check. Besides re-running and examining the notebook outputs
+manually, this command will automatically re-run the specified notebook
+and compare outputs for you:
+
+::
+
+    pytest --nb-test-files --nb-exec-timeout=500 system_availability_example.ipynb
+
+
 Checking for code style
 -----------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ versionfile_build = rdtools/_version.py
 tag_prefix = ''
 parentdir_prefix = rdtools-
 
+
 [metadata]
 description-file = README.md
 
@@ -17,8 +18,10 @@ description-file = README.md
 [bdist_wheel]
 universal = 1
 
+
 [aliases]
 test = pytest
+
 
 [tool:pytest]
 addopts = --verbose
@@ -26,3 +29,16 @@ addopts = --verbose
 # https://docs.python.org/3/library/warnings.html#the-warnings-filter
 filterwarnings =
     ignore:The .* module is currently experimental:UserWarning:rdtools
+
+## pytest-notebook configuration:
+## https://pytest-notebook.readthedocs.io/en/latest/user_guide/tutorial_config.html
+
+# don't check metadata like which specific version of python 3.7.x was used
+nb_diff_ignore =
+    /metadata/language_info
+
+# warning messages (like our experimental warnings) include a filepath which
+# changes based on the installation environment. The filepath itself isn't
+# interesting and doesn't need to be tested, so replace it with some dummy text:
+nb_diff_replace =
+    /cells/*/outputs/*/text "^.*: UserWarning:" "FILEPATH: UserWarning:"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,14 @@ filterwarnings =
 ## pytest-notebook configuration:
 ## https://pytest-notebook.readthedocs.io/en/latest/user_guide/tutorial_config.html
 
-# don't check metadata like which specific version of python 3.7.x was used
 nb_diff_ignore =
+
+    # don't check metadata like which specific version of python 3.7.x was used
     /metadata/language_info
+
+	# the regex replacement below helps, but there's still a bunch of spurious non-text
+	# data that the regex doesn't check.  So just ignore all "data" outputs (plots, mostly)
+    /cells/*/outputs/*/data
 
 # regex replacements to apply prior to comparing notebook outputs
 nb_diff_replace =
@@ -47,4 +52,4 @@ nb_diff_replace =
 
     # also blank out the "data" fields *before* running the diff.  otherwise plotly
     # output would make it run several times longer (several tens of minutes?).
-   /cells/*/outputs/*/data '(.|\n)*' ""
+   /cells/*/outputs/*/data ".*" ""

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,14 @@ filterwarnings =
 nb_diff_ignore =
     /metadata/language_info
 
-# warning messages (like our experimental warnings) include a filepath which
-# changes based on the installation environment. The filepath itself isn't
-# interesting and doesn't need to be tested, so replace it with some dummy text:
+# regex replacements to apply prior to comparing notebook outputs
 nb_diff_replace =
-    /cells/*/outputs/*/text "^.*: UserWarning:" "FILEPATH: UserWarning:"
+
+    # warning messages (like our experimental warnings) include a filepath which
+    # changes based on the installation environment. The filepath itself isn't
+    # interesting and doesn't need to be tested, so replace it with some dummy text.
+    /cells/*/outputs/*/text ".*: UserWarning:" "FILEPATH: UserWarning:"
+
+    # also blank out the "data" fields *before* running the diff.  otherwise plotly
+    # output would make it run several times longer (several tens of minutes?).
+   /cells/*/outputs/*/data '(.|\n)*' ""

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ TESTS_REQUIRE = [
     'coverage',
     'flake8',
     'pytest-mock',
+    'pytest-notebook==0.6.1',
 ]
 
 INSTALL_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ SETUP_REQUIRES = [
 
 TESTS_REQUIRE = [
     'pytest >= 3.6.3',
+    'coverage',
+    'flake8',
+    'pytest-mock',
 ]
 
 INSTALL_REQUIRES = [
@@ -61,12 +64,7 @@ EXTRAS_REQUIRE = {
         # https://nbsphinx.readthedocs.io/en/0.6.0/subdir/gallery.html#Creating-Thumbnail-Galleries
         'sphinx-gallery==0.8.1',
     ],
-    'test': [
-        'pytest',
-        'coverage',
-        'flake8',
-        'pytest-mock',
-    ]
+    'test': TESTS_REQUIRE,
 }
 EXTRAS_REQUIRE['all'] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))
 


### PR DESCRIPTION
- [ ] Code changes are covered by tests
- [ ] Code changes have been evaluated for compatibility/integration with TrendAnalysis
- [ ] New functions added to `__init__.py`
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] Updated changelog

`pytest-notebook` is a pytest plugin for re-running notebooks and comparing outputs with the original.  This PR is an alternative to #270, which used `nbval` for the same purpose. 