### PR TITLE
Add CI notebook check using pytest-notebook

### DIFF
--- a/.github/workflows/pytest-notebook.yaml
+++ b/.github/workflows/pytest-notebook.yaml
@@ -1,0 +1,34 @@
+name: notebook-check
+
+on: [pull_request, push]
+
+jobs:
+  notebook-check:
+    strategy:
+      matrix:
+        notebook-file: [
+          'system_availability_example.ipynb',
+          'TrendAnalysis_example_pvdaq4.ipynb',
+          'degradation_and_soiling_example_pvdaq_4.ipynb'
+          # can't run the DKASC notebook here because it requires pre-downloaded data
+        ]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install test environment
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install -r requirements.txt -r docs/notebook_requirements.txt .[test]
+
+    # test notebook using pytest-notebook; see setup.cfg for configuration
+    - name: pytest-notebook 
+      run: | 
+        pytest --nb-test-files --nb-exec-timeout=500 docs/${{ matrix.notebook-file }}

--- a/docs/notebook_requirements.txt
+++ b/docs/notebook_requirements.txt
@@ -22,7 +22,7 @@ jupyter-core==4.6.3
 jupyter==1.0.0
 MarkupSafe==1.1.1
 mistune==0.8.3
-nbconvert==6.1.0
+nbconvert==5.6.1
 nbformat==5.0.7
 notebook==6.4.1
 numexpr==2.7.3

--- a/docs/sphinx/source/developer_notes.rst
+++ b/docs/sphinx/source/developer_notes.rst
@@ -132,6 +132,19 @@ specific details, you can run ``coverage html`` to generate a detailed HTML
 report at ``htmlcov/index.html`` to view in a browser.  
 
 
+Running the notebooks as tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Re-running the example notebooks to see if their outputs have changed is
+another good check. Besides re-running and examining the notebook outputs
+manually, this command will automatically re-run the specified notebook
+and compare outputs for you:
+
+::
+
+    pytest --nb-test-files --nb-exec-timeout=500 system_availability_example.ipynb
+
+
 Checking for code style
 -----------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ versionfile_build = rdtools/_version.py
 tag_prefix = ''
 parentdir_prefix = rdtools-
 
+
 [metadata]
 description-file = README.md
 
@@ -17,8 +18,10 @@ description-file = README.md
 [bdist_wheel]
 universal = 1
 
+
 [aliases]
 test = pytest
+
 
 [tool:pytest]
 addopts = --verbose
@@ -26,3 +29,27 @@ addopts = --verbose
 # https://docs.python.org/3/library/warnings.html#the-warnings-filter
 filterwarnings =
     ignore:The .* module is currently experimental:UserWarning:rdtools
+
+## pytest-notebook configuration:
+## https://pytest-notebook.readthedocs.io/en/latest/user_guide/tutorial_config.html
+
+nb_diff_ignore =
+
+    # don't check metadata like which specific version of python 3.7.x was used
+    /metadata/language_info
+
+	# the regex replacement below helps, but there's still a bunch of spurious non-text
+	# data that the regex doesn't check.  So just ignore all "data" outputs (plots, mostly)
+    /cells/*/outputs/*/data
+
+# regex replacements to apply prior to comparing notebook outputs
+nb_diff_replace =
+
+    # warning messages (like our experimental warnings) include a filepath which
+    # changes based on the installation environment. The filepath itself isn't
+    # interesting and doesn't need to be tested, so replace it with some dummy text.
+    /cells/*/outputs/*/text ".*: UserWarning:" "FILEPATH: UserWarning:"
+
+    # also blank out the "data" fields *before* running the diff.  otherwise plotly
+    # output would make it run several times longer (several tens of minutes?).
+   /cells/*/outputs/*/data ".*" ""

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,10 @@ SETUP_REQUIRES = [
 
 TESTS_REQUIRE = [
     'pytest >= 3.6.3',
+    'coverage',
+    'flake8',
+    'pytest-mock',
+    'pytest-notebook==0.6.1',
 ]
 
 INSTALL_REQUIRES = [
@@ -61,12 +65,7 @@ EXTRAS_REQUIRE = {
         # https://nbsphinx.readthedocs.io/en/0.6.0/subdir/gallery.html#Creating-Thumbnail-Galleries
         'sphinx-gallery==0.8.1',
     ],
-    'test': [
-        'pytest',
-        'coverage',
-        'flake8',
-        'pytest-mock',
-    ]
+    'test': TESTS_REQUIRE,
 }
 EXTRAS_REQUIRE['all'] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))
 


### PR DESCRIPTION
- [ ] Code changes are covered by tests
- [ ] Code changes have been evaluated for compatibility/integration with TrendAnalysis
- [ ] New functions added to `__init__.py`
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] Updated changelog

`pytest-notebook` is a pytest plugin for re-running notebooks and comparing outputs with the original.  This PR is an alternative to #270, which used `nbval` for the same purpose. 