### PR TITLE
[WIP] allow sub-daily inputs to degradation_year_on_year

### DIFF
--- a/rdtools/degradation.py
+++ b/rdtools/degradation.py
@@ -239,6 +239,9 @@ def degradation_year_on_year(energy_normalized, recenter=True,
     else:
         renorm = 1.0
 
+    is_leap_day = energy_normalized.index.strftime('%m-%d') == '02-28'
+    energy_normalized = energy_normalized.loc[~is_leap_day, :]
+
     energy_normalized = energy_normalized.reset_index()
     energy_normalized['energy'] = energy_normalized['energy'] / renorm
 

--- a/rdtools/degradation.py
+++ b/rdtools/degradation.py
@@ -225,12 +225,6 @@ def degradation_year_on_year(energy_normalized, recenter=True,
     energy_normalized.name = 'energy'
     energy_normalized.index.name = 'dt'
 
-    # Detect sub-daily data:
-    if min(np.diff(energy_normalized.index.values, n=1)) < \
-            np.timedelta64(23, 'h'):
-        raise ValueError('energy_normalized must not be '
-                         'more frequent than daily')
-
     # Detect less than 2 years of data
     if energy_normalized.index[-1] - energy_normalized.index[0] < \
             pd.Timedelta('730d'):


### PR DESCRIPTION
- [ ] Code changes are covered by tests
- [ ] Code changes have been evaluated for compatibility/integration with TrendAnalysis
- [ ] New functions added to `__init__.py`
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] Updated changelog

Experimental PR to look at running YoY with faster-than-daily inputs.  This is not necessarily a good idea and is not intended for general use. 