### PR TITLE
Bring sphinx updates from development to master

### DIFF
--- a/docs/sphinx/source/changelog/pending.rst
+++ b/docs/sphinx/source/changelog/pending.rst
@@ -11,5 +11,5 @@ Requirements
 * Bump ``ipython==7.16.3``, ``jupyter-console==6.4.0``,
   and ``prompt-toolkit==3.0.27`` in ``docs/notebook_requirements.txt``
   and bump ``Pillow==9.0.0`` in ``requirements.txt`` (:pull:`314`)
-* Bump ``nbsphinx`` version from 0.8.5 to 0.8.8 in the optional
-  ``[doc]`` requirements (:pull:`317`)
+* Bump ``sphinx`` version from 3.2 to 4.5 and ``nbsphinx`` version
+  from 0.8.5 to 0.8.8 in the optional ``[doc]`` requirements (:pull:`317`, :pull:`325`)

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -108,6 +108,21 @@ def setup(app):
     app.add_css_file("no_scrollbars.css")
 
 
+# Custom mathjax settings to get plotly graphs working in the notebook gallery
+# https://github.com/sphinx-doc/sphinx/issues/9563
+# https://github.com/spatialaudio/nbsphinx/issues/572#issuecomment-853389268
+# https://github.com/plotly/plotly.py/issues/3152#issuecomment-855432931
+
+mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+mathjax2_config = {
+    'tex2jax': {
+        'inlineMath': [['$', '$'], ['\\(', '\\)']],
+        'processEscapes': True,
+        'ignoreClass': 'document',
+        'processClass': 'math|output_area',
+    }
+}
+
 # %% helper functions for intelligent "View on Github" linking
 # based on
 # https://gist.github.com/flying-sheep/b65875c0ce965fbdd1d9e5d0b9851ef1

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ INSTALL_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     'doc': [
-        'sphinx==3.2',
+        'sphinx==4.5.0',
         'nbsphinx==0.8.8',
         'nbsphinx-link==1.3.0',
         'sphinx_rtd_theme==0.5.2',


### PR DESCRIPTION
- [ ] Code changes are covered by tests
- [ ] Code changes have been evaluated for compatibility/integration with TrendAnalysis
- [ ] New functions added to `__init__.py`
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] Updated changelog

The sphinx updates in #325 were merged to development but it would be nice to have them on master as well (see docs build failure in #326).  Merging development to master is not a good solution at this point because it has other changes we're not ready to merge to master yet, so this branch reflects an earlier state of the development branch with only the sphinx changes. 

Note: #325 was merged (not squash-and-merged), so we should probably do the same here to have the same commit history on master as we have on development. 