### PR TITLE
CODS follow-up

### DIFF
--- a/docs/cods_example.ipynb
+++ b/docs/cods_example.ipynb
@@ -336,29 +336,8 @@
       "15                 False  \n",
       "\n",
       "Bootstrapping for uncertainty analysis (16 realizations):\n",
-      "# 16 | Used: 0.4 min | Left: 0.0 min | Progress: [----------------------------->] 100 %"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/mdecegli/opt/anaconda3/envs/cods_test/lib/python3.10/site-packages/rdtools/soiling.py:1875: FutureWarning: In a future version of pandas all arguments of concat except for the argument 'objs' will be keyword-only\n",
-      "  concat_tot_mod = pd.concat([kdf.total_model for kdf in bt_kdfs], 1)\n",
-      "/Users/mdecegli/opt/anaconda3/envs/cods_test/lib/python3.10/site-packages/rdtools/soiling.py:1876: FutureWarning: In a future version of pandas all arguments of concat except for the argument 'objs' will be keyword-only\n",
-      "  concat_SR = pd.concat([kdf.soiling_ratio for kdf in bt_kdfs], 1)\n",
-      "/Users/mdecegli/opt/anaconda3/envs/cods_test/lib/python3.10/site-packages/rdtools/soiling.py:1877: FutureWarning: In a future version of pandas all arguments of concat except for the argument 'objs' will be keyword-only\n",
-      "  concat_r_s = pd.concat([kdf.soiling_rates for kdf in bt_kdfs], 1)\n",
-      "/Users/mdecegli/opt/anaconda3/envs/cods_test/lib/python3.10/site-packages/rdtools/soiling.py:1878: FutureWarning: In a future version of pandas all arguments of concat except for the argument 'objs' will be keyword-only\n",
-      "  concat_ce = pd.concat([kdf.cleaning_events for kdf in bt_kdfs], 1)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Final RMSE: 0.01723\n"
+      "# 16 | Used: 0.5 min | Left: 0.0 min | Progress: [----------------------------->] 100 %\n",
+      "Final RMSE: 0.01722\n"
      ]
     }
    ],

--- a/docs/sphinx/source/changelog/pending.rst
+++ b/docs/sphinx/source/changelog/pending.rst
@@ -8,7 +8,7 @@ Enhancements
   now shows the number of year-on-year slopes in addition to color coding points
   (:issue:`298`, :pull:`324`)
 * The Combined estimation Of Degradation and Soiling (CODS) algorithm is implemented
-  in the soiling module and illustrated in an example notebook (:pull:`150`)
+  in the soiling module and illustrated in an example notebook (:pull:`150`, :pull:`333`)
 * Circular block bootstrapping added as a method for calculating uncertainty in
   ``degradation_year_on_year()`` via the ``Uncertainty_method`` argument (:pull:`150`)
 

--- a/rdtools/soiling.py
+++ b/rdtools/soiling.py
@@ -1154,9 +1154,6 @@ class CODSAnalysis():
     adf_res : list
         The results of an Augmented Dickey-Fuller test (telling whether the
         residuals are stationary or not)
-    _parameters_n_weights : pandas.DataFrame
-        Contains information about the parameters used in each bootstrap model
-        fit, and the resultant weight.
 
     Raises
     ------
@@ -1293,13 +1290,11 @@ class CODSAnalysis():
             +------------------------+----------------------------------------------+
             | Key                    | Description                                  |
             +========================+==============================================+
-            | 'degradation'          | List of linear degradation rate of system in |
-            |                        | %/year, lower and upper bound of 95%         |
-            |                        | confidence interval (list)                   |
+            | 'degradation'          | Linear degradation rate of system in %/year  |
+            |                        | (float)                                      |
             +------------------------+----------------------------------------------+
-            | 'soiling_loss'         | List of average soiling losses over the time |
-            |                        | series in %, lower and upper bound of 95%    |
-            |                        | confidence interval (list)                   |
+            | 'soiling_loss'         | Average soiling losses over the time series  |
+            |                        | in % (float)                                 |
             +------------------------+----------------------------------------------+
             | 'residual_shift'       | Mean value of residuals. Multiply total      |
             |                        | model by this number for complete overlap    |

--- a/rdtools/soiling.py
+++ b/rdtools/soiling.py
@@ -1872,10 +1872,10 @@ class CODSAnalysis():
         ci_high_edge = (50 + confidence_level / 2) / 100
 
         # Concatenate boostrap model fits
-        concat_tot_mod = pd.concat([kdf.total_model for kdf in bt_kdfs], 1)
-        concat_SR = pd.concat([kdf.soiling_ratio for kdf in bt_kdfs], 1)
-        concat_r_s = pd.concat([kdf.soiling_rates for kdf in bt_kdfs], 1)
-        concat_ce = pd.concat([kdf.cleaning_events for kdf in bt_kdfs], 1)
+        concat_tot_mod = pd.concat([kdf.total_model for kdf in bt_kdfs], axis=1)
+        concat_SR = pd.concat([kdf.soiling_ratio for kdf in bt_kdfs], axis=1)
+        concat_r_s = pd.concat([kdf.soiling_rates for kdf in bt_kdfs], axis=1)
+        concat_ce = pd.concat([kdf.cleaning_events for kdf in bt_kdfs], axis=1)
 
         # Find confidence intervals for SR and soiling rates
         df_out['SR_low'] = concat_SR.quantile(ci_low_edge, 1)


### PR DESCRIPTION
- ~[ ] Code changes are covered by tests~
- ~[ ] Code changes have been evaluated for compatibility/integration with TrendAnalysis~
- ~[ ] New functions added to `__init__.py`~
- ~[ ] API.rst is up to date, along with other sphinx docs pages~
- ~[ ] Example notebooks are rerun and differences in results scrutinized~
- ~[ ] Updated changelog~

Addresses items 1 and 2 from #330:
> 1. `pd.concat` causes a `FutureWarning` (see notebook example)
> 2. Rename parameters with `_tuner` in the name

And also the docstring description issue noted in https://github.com/NREL/rdtools/issues/330#issuecomment-1175210253, plus removing a private attribute from the docstring.