### PR TITLE
remove warnings from logic clip filter

### DIFF
--- a/rdtools/filtering.py
+++ b/rdtools/filtering.py
@@ -471,11 +471,11 @@ def logic_clip_filter(power_ac,
        detection techniques in AC power time series", 2021 IEEE 48th Photovoltaic
        Specialists Conference (PVSC). DOI: 10.1109/PVSC43889.2021.9518733.
     '''
-    # Throw a warning that this is still an experimental filter
-    warnings.warn("The logic-based filter is an experimental clipping filter "
-                  "that is still under development. The API, results, and "
-                  "default behaviors may change in future releases (including "
-                  "MINOR and PATCH). Use at your own risk!")
+    # Throw a warning that this is still an experimental filter. (Removed for 3.0.0)
+    #warnings.warn("The logic-based filter is an experimental clipping filter "
+    #              "that is still under development. The API, results, and "
+    #              "default behaviors may change in future releases (including "
+    #              "MINOR and PATCH). Use at your own risk!")
     # Format the time series
     power_ac, index_name = _format_clipping_time_series(power_ac,
                                                         mounting_type)


### PR DESCRIPTION
~~Code changes are covered by tests~~
~~Code changes have been evaluated for compatibility/integration with TrendAnalysis~~
~~New functions added to `__init__.py`~~
~~API.rst is up to date, along with other sphinx docs pages~~
~~Example notebooks are rerun and differences in results scrutinized~~
- [ ] Updated changelog

Fixes #365.  Logic clipping filter is published and validated, not likely to change in the future.  for the 3.0 release (and 3.0.0a1 runs) it would be nice to get rid of the logfile clutter.  We can still decide on whether to make it the default method or not, but the method itself is stable, or at least will be by the time of any 3.0.0 public release..