### PR TITLE
return results instead of none when CODS soiling signal is small

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ rdtools.egg-info*
 .\#*
 
 *.pickle
+
+# ignore vscode settings
+.vscode/

--- a/docs/sphinx/source/changelog.rst
+++ b/docs/sphinx/source/changelog.rst
@@ -1,5 +1,6 @@
 RdTools Change Log
 ==================
+.. include:: changelog/v2.2.0-beta.2.rst
 .. include:: changelog/v2.2.0-beta.1.rst
 .. include:: changelog/v2.1.8.rst
 .. include:: changelog/v2.1.7.rst

--- a/docs/sphinx/source/changelog/v2.2.0-beta.2.rst
+++ b/docs/sphinx/source/changelog/v2.2.0-beta.2.rst
@@ -13,6 +13,10 @@ Bug fixes
 * Specify dtype for seasonal samples ``soiling.py`` (:pull:`400`)
 * Update deprecated `check_less_precise` to `rtol` ``soiling_cods_test.py`` (:pull:`400`)
 
+Requirements
+------------
+* Bump arch to 5.6.0 in ``requirements.txt``
+
 Contributors
 ------------
 * Martin Springer (:ghuser:`martin-springer`)

--- a/docs/sphinx/source/changelog/v2.2.0-beta.2.rst
+++ b/docs/sphinx/source/changelog/v2.2.0-beta.2.rst
@@ -1,0 +1,19 @@
+********************************
+v2.2.0-beta.2 (December 1, 2023)
+********************************
+
+Enhancements
+------------
+* Return CODS results without bootstrapping when soiling signal
+  is small but raise warning ``soiling.py`` (:issue:`367` :pull:`400`)
+
+Bug fixes
+---------
+* Fix flake8 missing whitespaces ``bootstrap_test.py``, ``soiling_cods_test.py`` (:pull:`400`)
+* Specify dtype for seasonal samples ``soiling.py`` (:pull:`400`)
+* Update deprecated `check_less_precise` to `rtol` ``soiling_cods_test.py`` (:pull:`400`)
+
+Contributors
+------------
+* Martin Springer (:ghuser:`martin-springer`)
+* Michael Deceglie (:ghuser:`mdeceglie`)

--- a/rdtools/soiling.py
+++ b/rdtools/soiling.py
@@ -1762,10 +1762,10 @@ class CODSAnalysis():
             self.soiling_loss = [0, 0, (1 - result_df.soiling_ratio).mean()]
             self.small_soiling_signal = True
             self.errors = (
-                'Soiling signal is small relative to the noise.'
-                'Iterative decomposition not possible.\n'
-                'Degradation found by RdTools YoY')
-            print(self.errors)
+                'Soiling signal is small relative to the noise. '
+                'Iterative decomposition not possible. '
+                'Degradation found by RdTools YoY.')
+            warnings.warn(self.errors)
             return self.result_df, self.degradation, self.soiling_loss
         self.small_soiling_signal = False
 

--- a/rdtools/soiling.py
+++ b/rdtools/soiling.py
@@ -2507,7 +2507,8 @@ def _make_seasonal_samples(list_of_SCs, sample_nr=10, min_multiplier=0.5,
     ''' Generate seasonal samples by perturbing the amplitude and the phase of
         a seasonal components found with the fitted CODS model '''
     samples = pd.DataFrame(index=list_of_SCs[0].index,
-                           columns=range(int(sample_nr*len(list_of_SCs))))
+                           columns=range(int(sample_nr*len(list_of_SCs))),
+                           dtype=float)
     # From each fitted signal, we will generate new seaonal components
     for i, signal in enumerate(list_of_SCs):
         # Remove beginning and end of signal

--- a/rdtools/soiling.py
+++ b/rdtools/soiling.py
@@ -1766,7 +1766,7 @@ class CODSAnalysis():
                 'Iterative decomposition not possible.\n'
                 'Degradation found by RdTools YoY')
             print(self.errors)
-            return
+            return self.result_df, self.degradation, self.soiling_loss
         self.small_soiling_signal = False
 
         # Aggregate all bootstrap samples

--- a/rdtools/test/bootstrap_test.py
+++ b/rdtools/test/bootstrap_test.py
@@ -1,6 +1,6 @@
 '''Bootstrap module tests.'''
 
-from rdtools.bootstrap import _construct_confidence_intervals,\
+from rdtools.bootstrap import _construct_confidence_intervals, \
     _make_time_series_bootstrap_samples
 from rdtools.degradation import degradation_year_on_year
 

--- a/rdtools/test/conftest.py
+++ b/rdtools/test/conftest.py
@@ -126,6 +126,16 @@ def cods_normalized_daily(cods_normalized_daily_wo_noise):
     return cods_normalized_daily
 
 
+@pytest.fixture()
+def cods_normalized_daily_small_soiling(cods_normalized_daily_wo_noise):
+    N = len(cods_normalized_daily_wo_noise)
+    np.random.seed(1977)
+    noise = 1 + 0.02 * (np.random.rand(N) - 0.5)
+    cods_normalized_daily_small_soiling = cods_normalized_daily_wo_noise.apply(
+        lambda row: 1-(1-row)*0.1) * noise
+    return cods_normalized_daily_small_soiling
+
+
 # %% Availability fixtures
 
 ENERGY_PARAMETER_SPACE = list(itertools.product(

--- a/rdtools/test/soiling_cods_test.py
+++ b/rdtools/test/soiling_cods_test.py
@@ -48,7 +48,7 @@ def test_iterative_signal_decomposition(cods_normalized_daily):
         ['soiling_ratio', 'soiling_rates', 'cleaning_events',
          'seasonal_component', 'degradation_trend', 'total_model', 'residuals']]
     pd.testing.assert_series_equal(expected_means, df_out.mean(),
-                                   check_exact=False, check_less_precise=True)
+                                   check_exact=False, rtol=1e-3)
 
 
 def test_iterative_signal_decomposition_with_nan_interval(cods_normalized_daily):
@@ -85,7 +85,7 @@ def test_iterative_signal_decomposition_with_nan_interval(cods_normalized_daily)
         ['soiling_ratio', 'soiling_rates', 'cleaning_events',
          'seasonal_component', 'degradation_trend', 'total_model', 'residuals']]
     pd.testing.assert_series_equal(expected_means, df_out.mean(),
-                                   check_exact=False, check_less_precise=True)
+                                   check_exact=False, rtol=1e-3)
 
 
 def test_soiling_cods(cods_normalized_daily):

--- a/rdtools/test/soiling_cods_test.py
+++ b/rdtools/test/soiling_cods_test.py
@@ -12,17 +12,17 @@ def test_iterative_signal_decomposition(cods_normalized_daily):
     cods = soiling.CODSAnalysis(cods_normalized_daily)
     df_out, results_dict = \
         cods.iterative_signal_decomposition()
-    assert 0.080641 == pytest.approx(results_dict['degradation'], abs=1e-6),\
+    assert 0.080641 == pytest.approx(results_dict['degradation'], abs=1e-6), \
         'Degradation rate different from expected value'
-    assert 3.305136 == pytest.approx(results_dict['soiling_loss'], abs=1e-6),\
+    assert 3.305136 == pytest.approx(results_dict['soiling_loss'], abs=1e-6), \
         'Soiling loss different from expected value'
-    assert 0.999359 == pytest.approx(results_dict['residual_shift'], abs=1e-6),\
+    assert 0.999359 == pytest.approx(results_dict['residual_shift'], abs=1e-6), \
         'Residual shift different from expected value'
-    assert 0.008144 == pytest.approx(results_dict['RMSE'], abs=1e-6),\
+    assert 0.008144 == pytest.approx(results_dict['RMSE'], abs=1e-6), \
         'RMSE different from expected value'
     assert not results_dict['small_soiling_signal'], \
         'Small soiling signal assertion different from expected value'
-    assert 7.019626e-11 == pytest.approx(results_dict['adf_res'][1], abs=1e-6),\
+    assert 7.019626e-11 == pytest.approx(results_dict['adf_res'][1], abs=1e-6), \
         'p-value of Augmented Dickey-Fuller test different from expected value'
 
     # Check result dataframe
@@ -31,10 +31,10 @@ def test_iterative_signal_decomposition(cods_normalized_daily):
          'seasonal_component', 'degradation_trend', 'total_model', 'residuals']
     actual_columns = df_out.columns.values
     for x in actual_columns:
-        assert x in expected_columns,\
+        assert x in expected_columns, \
             "'{}' not an expected column in result_df]".format(x)
     for x in expected_columns:
-        assert x in actual_columns,\
+        assert x in actual_columns, \
             "'{}' was expected as a column, but not in result_df".format(x)
     assert isinstance(df_out, pd.DataFrame), 'result_df not a dataframe'
     expected_means = pd.Series({'soiling_ratio': 0.9669486267086722,
@@ -59,17 +59,17 @@ def test_iterative_signal_decomposition_with_nan_interval(cods_normalized_daily)
     cods = soiling.CODSAnalysis(normalized_corrupt)
     df_out, results_dict = \
         cods.iterative_signal_decomposition()
-    assert -0.004968 == pytest.approx(results_dict['degradation'], abs=1e-5),\
+    assert -0.004968 == pytest.approx(results_dict['degradation'], abs=1e-5), \
         'Degradation rate different from expected value'
-    assert 3.232171 == pytest.approx(results_dict['soiling_loss'], abs=1e-5),\
+    assert 3.232171 == pytest.approx(results_dict['soiling_loss'], abs=1e-5), \
         'Soiling loss different from expected value'
-    assert 1.000108 == pytest.approx(results_dict['residual_shift'], abs=1e-5),\
+    assert 1.000108 == pytest.approx(results_dict['residual_shift'], abs=1e-5), \
         'Residual shift different from expected value'
-    assert 0.008184 == pytest.approx(results_dict['RMSE'], abs=1e-5),\
+    assert 0.008184 == pytest.approx(results_dict['RMSE'], abs=1e-5), \
         'RMSE different from expected value'
     assert not results_dict['small_soiling_signal'], \
         'Small soiling signal assertion different from expected value'
-    assert 1.230754e-8 == pytest.approx(results_dict['adf_res'][1], abs=1e-6),\
+    assert 1.230754e-8 == pytest.approx(results_dict['adf_res'][1], abs=1e-6), \
         'p-value of Augmented Dickey-Fuller test different from expected value'
 
     # Check result dataframe
@@ -93,13 +93,13 @@ def test_soiling_cods(cods_normalized_daily):
     reps = 16
     np.random.seed(1977)
     sr, sr_ci, deg, deg_ci, result_df = soiling.soiling_cods(cods_normalized_daily, reps=reps)
-    assert 0.962207 == pytest.approx(sr, abs=0.5),\
+    assert 0.962207 == pytest.approx(sr, abs=0.5), \
         'Soiling ratio different from expected value'
-    assert np.array([0.96662419, 0.95692131]) == pytest.approx(sr_ci, abs=0.5),\
+    assert np.array([0.96662419, 0.95692131]) == pytest.approx(sr_ci, abs=0.5), \
         'Confidence interval of SR different from expected value'
-    assert 0.09 == pytest.approx(deg, abs=0.5),\
+    assert 0.09 == pytest.approx(deg, abs=0.5), \
         'Degradation rate different from expected value'
-    assert np.array([-0.17143952,  0.39313724]) == pytest.approx(deg_ci, abs=0.5),\
+    assert np.array([-0.17143952,  0.39313724]) == pytest.approx(deg_ci, abs=0.5), \
         'Confidence interval of degradation rate different from expected value'
 
     # Check result dataframe
@@ -111,10 +111,10 @@ def test_soiling_cods(cods_normalized_daily):
          'model_high']
     actual_summary_columns = result_df.columns.values
     for x in actual_summary_columns:
-        assert x in expected_summary_columns,\
+        assert x in expected_summary_columns, \
             "'{}' not an expected column in result_df]".format(x)
     for x in expected_summary_columns:
-        assert x in actual_summary_columns,\
+        assert x in actual_summary_columns, \
             "'{}' was expected as a column, but not in result_df".format(x)
 
 
@@ -131,7 +131,7 @@ def test_Kalman_filter_for_SR(cods_normalized_daily):
                         'soiling_rates', 'cleaning_events', 'days_since_ce']
     actual_columns = dfk.columns.values
     for x in actual_columns:
-        assert x in expected_columns,\
+        assert x in expected_columns, \
             "'{}' not an expected column in Kalman Filter results]".format(x)
     for x in expected_columns:
         assert x in actual_columns,\

--- a/rdtools/test/soiling_cods_test.py
+++ b/rdtools/test/soiling_cods_test.py
@@ -118,6 +118,19 @@ def test_soiling_cods(cods_normalized_daily):
             "'{}' was expected as a column, but not in result_df".format(x)
 
 
+def test_soiling_cods_small_signal(cods_normalized_daily_small_soiling):
+    ''' Test the CODS algorithm with small soiling signal'''
+    reps = 16
+    np.random.seed(1977)
+    warn_small_signal = (
+                'Soiling signal is small relative to the noise. '
+                'Iterative decomposition not possible. '
+                'Degradation found by RdTools YoY.')
+
+    with pytest.warns(UserWarning, match=warn_small_signal):
+        soiling.soiling_cods(cods_normalized_daily_small_soiling, reps=reps)
+
+
 def test_Kalman_filter_for_SR(cods_normalized_daily):
     '''Test the Kalman Filter method in CODS'''
     cods = soiling.CODSAnalysis(cods_normalized_daily)

--- a/rdtools/test/soiling_cods_test.py
+++ b/rdtools/test/soiling_cods_test.py
@@ -134,7 +134,7 @@ def test_Kalman_filter_for_SR(cods_normalized_daily):
         assert x in expected_columns, \
             "'{}' not an expected column in Kalman Filter results]".format(x)
     for x in expected_columns:
-        assert x in actual_columns,\
+        assert x in actual_columns, \
             "'{}' was expected as a column, but not in Kalman Filter results".format(x)
     assert Ps.shape == (732, 2, 2), "Shape of array of covariance matrices (Ps) not as expected"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pvlib==0.9.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
 pytz==2019.3
-arch==4.11
+arch==5.6.0
 filterpy==1.4.5
 requests==2.31.0
 retrying==1.3.3


### PR DESCRIPTION
- [x] Code changes are covered by tests
- [x] Code changes have been evaluated for compatibility/integration with TrendAnalysis
- ~~[ ] New functions added to `__init__.py`~~
- ~~[ ] API.rst is up to date, along with other sphinx docs pages~~
- [x] Example notebooks are rerun and differences in results scrutinized
- [x] Updated changelog