### PR TITLE
statsmodels 0.14.4 is not able to handle the latest scipy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ INSTALL_REQUIRES = [
     "numpy >= 1.22.4",
     "pandas >= 1.4.4",
     "statsmodels >= 0.13.5",
-    "scipy >= 1.8.1",
+    # statsmodels 0.14.4 is not able to handle the latest scipy
+    "scipy >= 1.8.1, <1.16.0",
     "h5py >= 3.7.0",
     "plotly>=4.0.0",
     "xgboost >= 1.6.0",


### PR DESCRIPTION
Need to keep scipy < 1.16 until Statsmodels gets a new release.  Per this issue: https://github.com/statsmodels/statsmodels/issues/9584

- [ ] Updated changelog
~[ ] Code changes are covered by tests~
~[ ] Code changes have been evaluated for compatibility/integration with TrendAnalysis~
~[ ] New functions added to `__init__.py`~
~[ ] API.rst is up to date, along with other sphinx docs pages~
~[ ] Example notebooks are rerun and differences in results scrutinized~
