### PR TITLE
remove scipy restrictions in setup.py now that statsmodels has a new release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,7 @@ INSTALL_REQUIRES = [
     "numpy >= 1.22.4",
     "pandas >= 1.4.4",
     "statsmodels >= 0.13.5",
-    # statsmodels 0.14.4 is not able to handle the latest scipy
-    "scipy >= 1.8.1, <1.16.0",
+    "scipy >= 1.8.1",
     "h5py >= 3.7.0",
     "plotly>=4.0.0",
     "xgboost >= 1.6.0",


### PR DESCRIPTION
- [ ] Code changes are covered by tests
- [ ] Code changes have been evaluated for compatibility/integration with TrendAnalysis
- [ ] New functions added to `__init__.py`
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] Updated changelog